### PR TITLE
chore(docs): add PR metadata standards template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+## Summary
+
+- What changed?
+- Why was this change needed?
+
+## Scope
+
+- [ ] Core PR reviewer
+- [ ] Chatbot / Teams
+- [ ] KB sync
+- [ ] Release notes
+- [ ] Sprint report
+- [ ] Test generation
+- [ ] PR description
+- [ ] Terraform / IaC
+- [ ] Docs / runbooks
+- [ ] CI / quality gates
+
+## Validation
+
+- [ ] `ruff check src tests scripts`
+- [ ] `pytest -q`
+- [ ] `terraform fmt -check` (if IaC changed)
+- [ ] `terraform validate` (if IaC changed)
+
+## PR Title Convention
+
+Use a scoped title that reflects shipped impact (this becomes the squash commit subject):
+
+- `feat(scope): short outcome`
+- `fix(scope): short outcome`
+- `chore(scope): short outcome`
+
+Examples:
+
+- `feat(reviewer): add Jira enrichment for ticket-aware findings`
+- `feat(platform): add sprint report, test-gen, and PR description agents`
+- `chore(ci): add lint/test and terraform quality gates`

--- a/README.md
+++ b/README.md
@@ -191,6 +191,24 @@ Run the same checks locally:
 - `make install`
 - `make check`
 
+## PR metadata standards
+
+To keep merge history clean and release notes accurate, use scoped PR titles since squash-merge uses the PR title as the commit subject.
+
+Preferred format:
+
+- `feat(scope): short outcome`
+- `fix(scope): short outcome`
+- `chore(scope): short outcome`
+
+Examples:
+
+- `feat(reviewer): add Jira enrichment for ticket-aware findings`
+- `feat(platform): add sprint report, test-gen, and PR description agents`
+- `chore(ci): add lint/test and terraform quality gates`
+
+Use the repository PR template at `.github/pull_request_template.md` to keep scope and validation checks consistent.
+
 ## Operations runbook
 
 ### Idempotency


### PR DESCRIPTION
## Summary
- add a repository PR template with scope + validation checklist
- document PR title/squash commit naming conventions in README

## Validation
- docs-only change; no runtime code path modified