### PR TITLE
feat(auth): add optional chatbot JWT/GitHub OAuth login modes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,20 @@ on:
     branches: ["main"]
 
 jobs:
+  pr-title-convention:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate PR title convention (optional)
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          python scripts/validate_pr_title.py "$PR_TITLE"
+
   lint-and-test:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Worker Lambda env vars:
 - `REVIEW_COMMENT_MODE=summary_only|inline_best_effort|strict_inline`
 - `CHATBOT_MODEL_ID` (Jira/Confluence chatbot model)
 - `ATLASSIAN_CREDENTIALS_SECRET_ARN`
+- `CHATBOT_API_TOKEN` or `CHATBOT_API_TOKEN_SECRET_ARN` (used when `chatbot_auth_mode=token`)
+- `TEAMS_ADAPTER_TOKEN` or `TEAMS_ADAPTER_TOKEN_SECRET_ARN` (used for `/chatbot/teams` when `chatbot_auth_mode=token`)
 
 Webhook Lambda env vars:
 
@@ -90,6 +92,13 @@ Chatbot endpoint:
   - `jira_jql` (optional)
   - `confluence_cql` (optional)
   - `retrieval_mode` (optional: `live|kb|hybrid`; defaults to `hybrid`)
+
+Chatbot login/auth options (Terraform `chatbot_auth_mode`):
+
+- `token` (default): shared header tokens
+- `jwt`: API Gateway JWT authorizer using company SSO/OIDC (`chatbot_jwt_issuer`, `chatbot_jwt_audience`)
+- `github_oauth`: API Gateway Lambda authorizer validates GitHub OAuth bearer tokens (`Authorization: Bearer <token>`)
+  - Optional org restriction: `github_oauth_allowed_orgs`
 
 Teams adapter endpoint:
 
@@ -185,6 +194,7 @@ This repository includes CI checks for pull requests and pushes to `main`:
 
 - Ruff linting (`python -m ruff check src tests scripts`)
 - Pytest unit tests (`python -m pytest -q`)
+- Optional PR title convention advisory (non-blocking on pull requests)
 
 Run the same checks locally:
 

--- a/infra/terraform/terraform.nonprod.tfvars.example
+++ b/infra/terraform/terraform.nonprod.tfvars.example
@@ -39,3 +39,12 @@ confluence_sync_limit      = 25
 # Teams adapter endpoint (enable only when testing Teams integration)
 teams_adapter_enabled = false
 teams_adapter_token   = ""
+
+# Chatbot route login/auth mode:
+# - token       => existing X-Api-Token / X-Teams-Adapter-Token checks inside Lambda
+# - jwt         => API Gateway JWT authorizer (company SSO/OIDC)
+# - github_oauth => API Gateway Lambda authorizer validates GitHub OAuth bearer token
+chatbot_auth_mode         = "token"
+chatbot_jwt_issuer        = ""
+chatbot_jwt_audience      = []
+github_oauth_allowed_orgs = []

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -47,6 +47,15 @@ teams_adapter_token   = ""
 # API authentication (leave empty to disable auth)
 chatbot_api_token = ""
 
+# Chatbot route login/auth mode:
+# - token       => existing X-Api-Token / X-Teams-Adapter-Token checks inside Lambda
+# - jwt         => API Gateway JWT authorizer (company SSO/OIDC)
+# - github_oauth => API Gateway Lambda authorizer validates GitHub OAuth bearer token
+chatbot_auth_mode     = "token"
+chatbot_jwt_issuer    = ""
+chatbot_jwt_audience  = []
+github_oauth_allowed_orgs = []
+
 # CloudWatch alarms (leave empty to disable alarms)
 alarm_sns_topic_arn = ""
 

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -187,6 +187,35 @@ variable "chatbot_api_token" {
   sensitive   = true
 }
 
+variable "chatbot_auth_mode" {
+  description = "Authentication mode for chatbot routes: token, jwt, or github_oauth"
+  type        = string
+  default     = "token"
+
+  validation {
+    condition     = contains(["token", "jwt", "github_oauth"], var.chatbot_auth_mode)
+    error_message = "Must be one of: token, jwt, github_oauth."
+  }
+}
+
+variable "chatbot_jwt_issuer" {
+  description = "OIDC issuer URL for JWT authorizer when chatbot_auth_mode=jwt"
+  type        = string
+  default     = ""
+}
+
+variable "chatbot_jwt_audience" {
+  description = "JWT audience values for chatbot JWT authorizer when chatbot_auth_mode=jwt"
+  type        = list(string)
+  default     = []
+}
+
+variable "github_oauth_allowed_orgs" {
+  description = "Optional GitHub org allow-list for github_oauth auth mode. Empty means any authenticated GitHub user token."
+  type        = list(string)
+  default     = []
+}
+
 variable "alarm_sns_topic_arn" {
   description = "Optional SNS topic ARN for CloudWatch alarm notifications. Alarms are created only when set."
   type        = string

--- a/scripts/validate_pr_title.py
+++ b/scripts/validate_pr_title.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Validate PR titles against repository convention.
+
+This script is intentionally lightweight and stdlib-only so it can run in CI
+without additional dependencies.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+PATTERN = re.compile(r"^(feat|fix|chore)\([a-z0-9_-]+\): .+")
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("::warning::No PR title provided; skipping convention check.")
+        return 0
+
+    title = sys.argv[1].strip()
+    if PATTERN.match(title):
+        print(f"PR title matches convention: {title}")
+        return 0
+
+    print("::warning::PR title does not match optional convention.")
+    print("Expected format: feat(scope): short outcome")
+    print("Also allowed: fix(scope): ..., chore(scope): ...")
+    print(f"Received: {title}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/chatbot/github_oauth_authorizer.py
+++ b/src/chatbot/github_oauth_authorizer.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import requests
+
+from shared.logging import get_logger
+
+logger = get_logger("chatbot_github_oauth_authorizer")
+
+
+def _parse_bearer_token(headers: dict[str, str] | None) -> str:
+    if not headers:
+        return ""
+
+    auth_header = ""
+    for key, value in headers.items():
+        if key.lower() == "authorization":
+            auth_header = value
+            break
+
+    if not auth_header:
+        return ""
+
+    parts = auth_header.strip().split(" ", 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        return ""
+
+    return parts[1].strip()
+
+
+def _allowed_orgs() -> set[str]:
+    raw = os.getenv("GITHUB_OAUTH_ALLOWED_ORGS", "")
+    return {org.strip().lower() for org in raw.split(",") if org.strip()}
+
+
+def _github_get(api_base: str, token: str, path: str) -> requests.Response:
+    return requests.get(
+        f"{api_base.rstrip('/')}{path}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        timeout=10,
+    )
+
+
+def _authorize(token: str) -> tuple[bool, dict[str, str]]:
+    api_base = os.getenv("GITHUB_API_BASE", "https://api.github.com").strip().rstrip("/")
+    user_resp = _github_get(api_base, token, "/user")
+    if user_resp.status_code != 200:
+        logger.warning("github_oauth_user_lookup_failed", extra={"extra": {"status": user_resp.status_code}})
+        return False, {}
+
+    user = user_resp.json()
+    login = str(user.get("login") or "")
+    if not login:
+        return False, {}
+
+    allowlist = _allowed_orgs()
+    if not allowlist:
+        return True, {"github_login": login, "auth_provider": "github_oauth"}
+
+    org_resp = _github_get(api_base, token, "/user/orgs")
+    if org_resp.status_code != 200:
+        logger.warning("github_oauth_org_lookup_failed", extra={"extra": {"status": org_resp.status_code}})
+        return False, {}
+
+    orgs = {str(org.get("login") or "").lower() for org in org_resp.json()}
+    if not orgs.intersection(allowlist):
+        logger.info(
+            "github_oauth_org_membership_denied",
+            extra={"extra": {"github_login": login, "required_orgs": sorted(allowlist)}},
+        )
+        return False, {}
+
+    return True, {"github_login": login, "auth_provider": "github_oauth"}
+
+
+def lambda_handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
+    headers = event.get("headers") or {}
+    token = _parse_bearer_token(headers)
+    if not token:
+        return {"isAuthorized": False}
+
+    request_id = event.get("requestContext", {}).get("requestId", "unknown")
+    try:
+        authorized, context = _authorize(token)
+    except (requests.RequestException, json.JSONDecodeError):
+        logger.exception(
+            "github_oauth_authorizer_error",
+            extra={"extra": {"request_id": request_id}},
+        )
+        return {"isAuthorized": False}
+
+    if not authorized:
+        return {"isAuthorized": False}
+
+    return {
+        "isAuthorized": True,
+        "context": context,
+    }

--- a/tests/test_github_oauth_authorizer.py
+++ b/tests/test_github_oauth_authorizer.py
@@ -1,0 +1,83 @@
+from unittest.mock import MagicMock, patch
+
+from chatbot.github_oauth_authorizer import _parse_bearer_token, lambda_handler
+
+
+def _event(auth_header: str | None) -> dict:
+    headers = {}
+    if auth_header is not None:
+        headers["Authorization"] = auth_header
+    return {
+        "headers": headers,
+        "requestContext": {"requestId": "req-123"},
+    }
+
+
+def _response(status_code: int, payload: dict | list) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = payload
+    return resp
+
+
+def test_parse_bearer_token_variants() -> None:
+    assert _parse_bearer_token({"Authorization": "Bearer abc"}) == "abc"
+    assert _parse_bearer_token({"authorization": "bearer xyz"}) == "xyz"
+    assert _parse_bearer_token({"Authorization": "Token xyz"}) == ""
+    assert _parse_bearer_token({}) == ""
+
+
+@patch("chatbot.github_oauth_authorizer.requests.get")
+def test_lambda_handler_denies_without_token(mock_get) -> None:
+    out = lambda_handler(_event(None), None)
+    assert out == {"isAuthorized": False}
+    mock_get.assert_not_called()
+
+
+@patch("chatbot.github_oauth_authorizer.requests.get")
+def test_lambda_handler_allows_github_user_without_org_restriction(mock_get) -> None:
+    mock_get.return_value = _response(200, {"login": "octocat"})
+    env = {
+        "GITHUB_API_BASE": "https://api.github.com",
+        "GITHUB_OAUTH_ALLOWED_ORGS": "",
+    }
+    with patch.dict("os.environ", env, clear=False):
+        out = lambda_handler(_event("Bearer valid-token"), None)
+
+    assert out["isAuthorized"] is True
+    assert out["context"]["github_login"] == "octocat"
+
+
+@patch("chatbot.github_oauth_authorizer.requests.get")
+def test_lambda_handler_denies_if_org_not_allowed(mock_get) -> None:
+    mock_get.side_effect = [
+        _response(200, {"login": "octocat"}),
+        _response(200, [{"login": "another-org"}]),
+    ]
+
+    env = {
+        "GITHUB_API_BASE": "https://api.github.com",
+        "GITHUB_OAUTH_ALLOWED_ORGS": "my-org,eng-org",
+    }
+    with patch.dict("os.environ", env, clear=False):
+        out = lambda_handler(_event("Bearer valid-token"), None)
+
+    assert out == {"isAuthorized": False}
+
+
+@patch("chatbot.github_oauth_authorizer.requests.get")
+def test_lambda_handler_allows_if_org_allowed(mock_get) -> None:
+    mock_get.side_effect = [
+        _response(200, {"login": "octocat"}),
+        _response(200, [{"login": "eng-org"}]),
+    ]
+
+    env = {
+        "GITHUB_API_BASE": "https://api.github.com",
+        "GITHUB_OAUTH_ALLOWED_ORGS": "my-org,eng-org",
+    }
+    with patch.dict("os.environ", env, clear=False):
+        out = lambda_handler(_event("Bearer valid-token"), None)
+
+    assert out["isAuthorized"] is True
+    assert out["context"]["auth_provider"] == "github_oauth"


### PR DESCRIPTION
## Summary
- add optional chatbot auth modes: token, jwt, and github_oauth
- add API Gateway authorizer wiring for chatbot routes
- add GitHub OAuth Lambda authorizer with optional org allow-list
- add docs/examples for auth mode configuration
- add optional non-blocking PR title convention advisory check

## Validation
- python -m ruff check src tests scripts
- python -m pytest -q tests/test_github_oauth_authorizer.py tests/test_chatbot_helpers.py tests/test_teams_adapter.py
- terraform fmt -check

## Notes
- terraform validate remains environment-dependent (requires terraform init and Terraform >= 1.6)