### PR TITLE
feat(kb): add scheduled GitHub docs sync to Bedrock KB

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ PR description generator endpoint:
 - `test_gen_url`
 - `pr_description_url`
 - `release_notes_url`
+- `github_kb_sync_function_name`
 
 ## Local testing
 
@@ -372,6 +373,25 @@ Terraform variables:
 When enabled, Terraform outputs:
 
 - `kb_sync_function_name`
+- `kb_sync_documents_bucket`
+
+### Scheduled GitHub docs -> Knowledge Base sync
+
+Optional scheduled sync job reads documentation files from selected GitHub repos, normalizes them into S3, and starts a Bedrock Knowledge Base ingestion job.
+
+Terraform variables:
+
+- `github_kb_sync_enabled`
+- `github_kb_data_source_id` (optional; falls back to `bedrock_kb_data_source_id`)
+- `github_kb_sync_schedule_expression`
+- `github_kb_sync_s3_prefix`
+- `github_kb_repos`
+- `github_kb_include_patterns`
+- `github_kb_max_files_per_repo`
+
+When enabled, Terraform outputs:
+
+- `github_kb_sync_function_name`
 - `kb_sync_documents_bucket`
 
 ### Teams adapter setup

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -38,9 +38,14 @@ output "kb_sync_function_name" {
   value       = var.kb_sync_enabled ? aws_lambda_function.confluence_kb_sync[0].function_name : ""
 }
 
+output "github_kb_sync_function_name" {
+  description = "Scheduled GitHub docs to Knowledge Base sync Lambda function name"
+  value       = var.github_kb_sync_enabled ? aws_lambda_function.github_kb_sync[0].function_name : ""
+}
+
 output "kb_sync_documents_bucket" {
   description = "S3 bucket storing normalized Confluence documents for KB ingestion"
-  value       = var.kb_sync_enabled ? aws_s3_bucket.kb_sync_documents[0].bucket : ""
+  value       = var.kb_sync_enabled || var.github_kb_sync_enabled ? aws_s3_bucket.kb_sync_documents[0].bucket : ""
 }
 
 output "release_notes_url" {

--- a/infra/terraform/terraform.nonprod.tfvars.example
+++ b/infra/terraform/terraform.nonprod.tfvars.example
@@ -36,6 +36,15 @@ kb_sync_s3_prefix          = "confluence"
 confluence_sync_cql        = "type=page order by lastmodified desc"
 confluence_sync_limit      = 25
 
+# Scheduled GitHub docs -> Bedrock Knowledge Base sync
+github_kb_sync_enabled              = false
+github_kb_data_source_id            = ""
+github_kb_sync_schedule_expression  = "rate(6 hours)"
+github_kb_sync_s3_prefix            = "github"
+github_kb_repos                     = ["my-org/my-repo"]
+github_kb_include_patterns          = ["README.md", "docs/**", "**/*.md"]
+github_kb_max_files_per_repo        = 200
+
 # Teams adapter endpoint (enable only when testing Teams integration)
 teams_adapter_enabled = false
 teams_adapter_token   = ""

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -40,6 +40,15 @@ kb_sync_s3_prefix = "confluence"
 confluence_sync_cql = "type=page order by lastmodified desc"
 confluence_sync_limit = 25
 
+# Scheduled GitHub docs -> Bedrock Knowledge Base sync
+github_kb_sync_enabled = false
+github_kb_data_source_id = ""
+github_kb_sync_schedule_expression = "rate(6 hours)"
+github_kb_sync_s3_prefix = "github"
+github_kb_repos = []
+github_kb_include_patterns = ["README.md", "docs/**", "**/*.md"]
+github_kb_max_files_per_repo = 200
+
 # Teams adapter endpoint
 teams_adapter_enabled = false
 teams_adapter_token   = ""

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -167,6 +167,58 @@ variable "confluence_sync_limit" {
   }
 }
 
+variable "github_kb_sync_enabled" {
+  description = "Enable scheduled GitHub docs to Bedrock Knowledge Base sync"
+  type        = bool
+  default     = false
+}
+
+variable "github_kb_data_source_id" {
+  description = "Optional Bedrock Knowledge Base data source ID for GitHub docs ingestion (falls back to bedrock_kb_data_source_id)"
+  type        = string
+  default     = ""
+}
+
+variable "github_kb_sync_schedule_expression" {
+  description = "EventBridge schedule expression for GitHub docs sync job"
+  type        = string
+  default     = "rate(6 hours)"
+
+  validation {
+    condition     = can(regex("^(rate|cron)\\(", var.github_kb_sync_schedule_expression))
+    error_message = "Must start with rate( or cron(."
+  }
+}
+
+variable "github_kb_sync_s3_prefix" {
+  description = "S3 prefix where normalized GitHub docs are written"
+  type        = string
+  default     = "github"
+}
+
+variable "github_kb_repos" {
+  description = "List of GitHub repositories (owner/repo) to sync into the Knowledge Base"
+  type        = list(string)
+  default     = []
+}
+
+variable "github_kb_include_patterns" {
+  description = "Glob-like file patterns to include for GitHub KB sync"
+  type        = list(string)
+  default     = ["README.md", "docs/**", "**/*.md"]
+}
+
+variable "github_kb_max_files_per_repo" {
+  description = "Maximum number of files synced per repository run"
+  type        = number
+  default     = 200
+
+  validation {
+    condition     = var.github_kb_max_files_per_repo >= 1
+    error_message = "Must be at least 1."
+  }
+}
+
 variable "teams_adapter_enabled" {
   description = "Enable Microsoft Teams adapter endpoint"
   type        = bool

--- a/scripts/predeploy_nonprod_checks.py
+++ b/scripts/predeploy_nonprod_checks.py
@@ -89,6 +89,19 @@ def main() -> int:
     if tfvars.get("kb_sync_enabled", "").lower() != "true":
         warnings.append("kb_sync_enabled is not true (scheduled sync disabled)")
 
+    github_kb_enabled = tfvars.get("github_kb_sync_enabled", "").lower() == "true"
+    if github_kb_enabled:
+        repos = tfvars.get("github_kb_repos", "")
+        if repos in {"", "[]"}:
+            failures.append("github_kb_sync_enabled=true but github_kb_repos is empty")
+
+        gh_data_source = tfvars.get("github_kb_data_source_id", "")
+        base_data_source = tfvars.get("bedrock_kb_data_source_id", "")
+        if gh_data_source in placeholder_markers and base_data_source in placeholder_markers:
+            failures.append(
+                "github_kb_sync_enabled=true but neither github_kb_data_source_id nor bedrock_kb_data_source_id is set"
+            )
+
     if tfvars.get("dry_run", "").lower() != "true":
         warnings.append("dry_run is not true; first non-prod rollout is safer with dry_run=true")
 

--- a/scripts/trigger_kb_sync.py
+++ b/scripts/trigger_kb_sync.py
@@ -8,8 +8,14 @@ import boto3
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Invoke Confluence->KB sync Lambda and print response")
-    parser.add_argument("--function-name", required=True, help="KB sync Lambda function name")
+    parser = argparse.ArgumentParser(
+        description="Invoke a KB sync Lambda (Confluence or GitHub docs) and print response"
+    )
+    parser.add_argument(
+        "--function-name",
+        required=True,
+        help="KB sync Lambda name (kb_sync_function_name or github_kb_sync_function_name)",
+    )
     parser.add_argument("--region", default="us-gov-west-1", help="AWS region")
     parser.add_argument("--qualifier", default="", help="Optional Lambda version or alias")
     args = parser.parse_args()

--- a/src/github_kb_sync/app.py
+++ b/src/github_kb_sync/app.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import boto3
+
+from shared.constants import DEFAULT_REGION
+from shared.github_app_auth import GitHubAppAuth
+from shared.github_client import GitHubClient
+from shared.logging import get_logger
+
+logger = get_logger("github_kb_sync")
+
+
+def _parse_csv_list(value: str, default: list[str] | None = None) -> list[str]:
+    items = [item.strip() for item in (value or "").split(",") if item.strip()]
+    if items:
+        return items
+    return list(default or [])
+
+
+def _parse_repo(value: str) -> tuple[str, str] | None:
+    parts = [p.strip() for p in value.split("/", 1)]
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        return None
+    return parts[0], parts[1]
+
+
+def _api_base_to_web_base(api_base: str) -> str:
+    base = api_base.rstrip("/")
+    if base == "https://api.github.com":
+        return "https://github.com"
+    if base.endswith("/api/v3"):
+        return base[: -len("/api/v3")]
+    return base
+
+
+def _matches(path: str, patterns: list[str]) -> bool:
+    for pattern in patterns:
+        if fnmatch.fnmatch(path, pattern):
+            return True
+    return False
+
+
+def _s3_key(prefix: str, owner: str, repo: str, ref: str, path: str) -> str:
+    safe_path = path.strip("/")
+    return f"{prefix.rstrip('/')}/repos/{owner}/{repo}/{ref}/{safe_path}.json"
+
+
+def _build_doc(*, owner: str, repo: str, ref: str, path: str, text: str, web_base: str) -> dict[str, Any]:
+    title = Path(path).name or path
+    return {
+        "id": f"{owner}/{repo}:{ref}:{path}",
+        "title": title,
+        "repo": f"{owner}/{repo}",
+        "path": path,
+        "ref": ref,
+        "url": f"{web_base}/{owner}/{repo}/blob/{ref}/{path}",
+        "source": "github",
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+        "text": text,
+    }
+
+
+def lambda_handler(_event: dict[str, Any], _context: Any) -> dict[str, Any]:
+    region = os.getenv("AWS_REGION", DEFAULT_REGION)
+    api_base = os.getenv("GITHUB_API_BASE", "https://api.github.com")
+    app_ids_secret_arn = os.environ["GITHUB_APP_IDS_SECRET_ARN"]
+    private_key_secret_arn = os.environ["GITHUB_APP_PRIVATE_KEY_SECRET_ARN"]
+    knowledge_base_id = os.environ["BEDROCK_KNOWLEDGE_BASE_ID"]
+    data_source_id = os.getenv("GITHUB_KB_DATA_SOURCE_ID", "").strip() or os.environ["BEDROCK_KB_DATA_SOURCE_ID"]
+    bucket = os.environ["KB_SYNC_BUCKET"]
+
+    repos = _parse_csv_list(os.getenv("GITHUB_KB_REPOS", ""))
+    include_patterns = _parse_csv_list(
+        os.getenv("GITHUB_KB_INCLUDE_PATTERNS", ""),
+        default=["README.md", "docs/**", "**/*.md"],
+    )
+    prefix = os.getenv("GITHUB_KB_SYNC_PREFIX", "github")
+    max_files_per_repo = max(1, int(os.getenv("GITHUB_KB_MAX_FILES_PER_REPO", "200")))
+    ref_override = os.getenv("GITHUB_KB_REF", "").strip()
+
+    auth = GitHubAppAuth(
+        app_ids_secret_arn=app_ids_secret_arn,
+        private_key_secret_arn=private_key_secret_arn,
+        api_base=api_base,
+    )
+    gh = GitHubClient(token_provider=auth.get_installation_token, api_base=api_base)
+
+    s3 = boto3.client("s3", region_name=region)
+    bedrock_agent = boto3.client("bedrock-agent", region_name=region)
+    web_base = _api_base_to_web_base(api_base)
+
+    uploaded = 0
+    failed = 0
+    skipped = 0
+    repos_processed = 0
+
+    for repo_slug in repos:
+        parsed = _parse_repo(repo_slug)
+        if not parsed:
+            logger.warning("invalid_repo_slug", extra={"extra": {"repo": repo_slug}})
+            failed += 1
+            continue
+
+        owner, repo = parsed
+        repos_processed += 1
+
+        try:
+            effective_ref = ref_override
+            if not effective_ref:
+                metadata = gh.get_repository(owner, repo)
+                effective_ref = str(metadata.get("default_branch") or "main")
+
+            files = gh.list_repository_files(owner, repo, effective_ref)
+            matches = [path for path in files if _matches(path, include_patterns)]
+            matches = matches[:max_files_per_repo]
+
+            for path in matches:
+                try:
+                    text, _sha = gh.get_file_contents(owner, repo, path, effective_ref)
+                    text = (text or "").strip()
+                    if not text:
+                        skipped += 1
+                        continue
+
+                    doc = _build_doc(
+                        owner=owner,
+                        repo=repo,
+                        ref=effective_ref,
+                        path=path,
+                        text=text,
+                        web_base=web_base,
+                    )
+                    s3.put_object(
+                        Bucket=bucket,
+                        Key=_s3_key(prefix, owner, repo, effective_ref, path),
+                        Body=json.dumps(doc).encode("utf-8"),
+                        ContentType="application/json",
+                    )
+                    uploaded += 1
+                except Exception:
+                    logger.exception("github_doc_sync_failed", extra={"extra": {"repo": repo_slug, "path": path}})
+                    failed += 1
+        except Exception:
+            logger.exception("github_repo_sync_failed", extra={"extra": {"repo": repo_slug}})
+            failed += 1
+
+    ingestion_job_id = ""
+    if uploaded > 0:
+        response = bedrock_agent.start_ingestion_job(
+            knowledgeBaseId=knowledge_base_id,
+            dataSourceId=data_source_id,
+            clientToken=str(uuid.uuid4()),
+            description="GitHub docs sync from chatbot platform",
+        )
+        ingestion_job_id = str((response.get("ingestionJob") or {}).get("ingestionJobId") or "")
+
+    logger.info(
+        "github_kb_sync_completed",
+        extra={
+            "extra": {
+                "repos_processed": repos_processed,
+                "uploaded": uploaded,
+                "failed": failed,
+                "skipped": skipped,
+                "ingestion_job_id": ingestion_job_id,
+                "knowledge_base_id": knowledge_base_id,
+            }
+        },
+    )
+
+    return {
+        "repos_processed": repos_processed,
+        "uploaded": uploaded,
+        "failed": failed,
+        "skipped": skipped,
+        "ingestion_job_id": ingestion_job_id,
+        "knowledge_base_id": knowledge_base_id,
+    }

--- a/src/shared/github_client.py
+++ b/src/shared/github_client.py
@@ -47,6 +47,10 @@ class GitHubClient:
         response = self._request("GET", f"/repos/{owner}/{repo}/pulls/{pull_number}")
         return response.json()
 
+    def get_repository(self, owner: str, repo: str) -> dict:
+        response = self._request("GET", f"/repos/{owner}/{repo}")
+        return response.json()
+
     def get_pull_request_files(self, owner: str, repo: str, pull_number: int) -> list[dict]:
         page = 1
         files: list[dict] = []
@@ -108,6 +112,17 @@ class GitHubClient:
         encoded = data.get("content", "").replace("\n", "")
         decoded = base64.b64decode(encoded).decode("utf-8")
         return decoded, data["sha"]
+
+    def list_repository_files(self, owner: str, repo: str, ref: str) -> list[str]:
+        """List all file paths in a repository tree for a given ref/branch."""
+        response = self._request(
+            "GET",
+            f"/repos/{owner}/{repo}/git/trees/{ref}",
+            params={"recursive": "1"},
+        )
+        data = response.json()
+        tree = data.get("tree") or []
+        return [str(item.get("path") or "") for item in tree if item.get("type") == "blob" and item.get("path")]
 
     def put_file_contents(
         self,

--- a/tests/test_github_kb_sync.py
+++ b/tests/test_github_kb_sync.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from github_kb_sync.app import _api_base_to_web_base, _matches, _parse_repo, lambda_handler
+
+
+def test_parse_repo() -> None:
+    assert _parse_repo("org/repo") == ("org", "repo")
+    assert _parse_repo("org") is None
+    assert _parse_repo("/") is None
+
+
+def test_api_base_to_web_base() -> None:
+    assert _api_base_to_web_base("https://api.github.com") == "https://github.com"
+    assert _api_base_to_web_base("https://ghe.example.com/api/v3") == "https://ghe.example.com"
+
+
+def test_matches() -> None:
+    patterns = ["README.md", "docs/**", "**/*.md"]
+    assert _matches("README.md", patterns)
+    assert _matches("docs/setup.md", patterns)
+    assert not _matches("src/app.py", patterns)
+
+
+@patch("github_kb_sync.app.boto3.client")
+@patch("github_kb_sync.app.GitHubClient")
+@patch("github_kb_sync.app.GitHubAppAuth")
+def test_lambda_handler_happy_path(mock_auth_cls, mock_gh_cls, mock_boto_client) -> None:
+    mock_auth = MagicMock()
+    mock_auth.get_installation_token.return_value = "token"
+    mock_auth_cls.return_value = mock_auth
+
+    mock_gh = MagicMock()
+    mock_gh.get_repository.return_value = {"default_branch": "main"}
+    mock_gh.list_repository_files.return_value = ["README.md", "docs/runbook.md", "src/app.py"]
+    mock_gh.get_file_contents.side_effect = [
+        ("repo readme", "sha1"),
+        ("runbook content", "sha2"),
+    ]
+    mock_gh_cls.return_value = mock_gh
+
+    mock_s3 = MagicMock()
+    mock_bedrock = MagicMock()
+    mock_bedrock.start_ingestion_job.return_value = {"ingestionJob": {"ingestionJobId": "job-123"}}
+
+    def _client(name: str, **_kwargs):
+        if name == "s3":
+            return mock_s3
+        if name == "bedrock-agent":
+            return mock_bedrock
+        raise AssertionError(name)
+
+    mock_boto_client.side_effect = _client
+
+    env = {
+        "AWS_REGION": "us-gov-west-1",
+        "GITHUB_API_BASE": "https://ghe.example.com/api/v3",
+        "GITHUB_APP_IDS_SECRET_ARN": "arn:ids",
+        "GITHUB_APP_PRIVATE_KEY_SECRET_ARN": "arn:key",
+        "BEDROCK_KNOWLEDGE_BASE_ID": "kb-1",
+        "BEDROCK_KB_DATA_SOURCE_ID": "ds-1",
+        "KB_SYNC_BUCKET": "bucket-1",
+        "GITHUB_KB_REPOS": "org/repo",
+        "GITHUB_KB_INCLUDE_PATTERNS": "README.md,docs/**",
+        "GITHUB_KB_SYNC_PREFIX": "github",
+        "GITHUB_KB_MAX_FILES_PER_REPO": "10",
+    }
+
+    with patch.dict("os.environ", env, clear=False):
+        out = lambda_handler({}, None)
+
+    assert out["uploaded"] == 2
+    assert out["failed"] == 0
+    assert out["repos_processed"] == 1
+    assert out["ingestion_job_id"] == "job-123"
+    assert mock_s3.put_object.call_count == 2
+
+    # Validate document contains expected source URL base conversion
+    first_body = mock_s3.put_object.call_args_list[0].kwargs["Body"]
+    payload = json.loads(first_body.decode("utf-8"))
+    assert payload["url"].startswith("https://ghe.example.com/org/repo/blob/main/")
+
+
+@patch("github_kb_sync.app.boto3.client")
+@patch("github_kb_sync.app.GitHubClient")
+@patch("github_kb_sync.app.GitHubAppAuth")
+def test_lambda_handler_no_uploads_skips_ingestion(mock_auth_cls, mock_gh_cls, mock_boto_client) -> None:
+    mock_auth_cls.return_value = MagicMock()
+
+    mock_gh = MagicMock()
+    mock_gh.get_repository.return_value = {"default_branch": "main"}
+    mock_gh.list_repository_files.return_value = ["src/app.py"]
+    mock_gh_cls.return_value = mock_gh
+
+    mock_s3 = MagicMock()
+    mock_bedrock = MagicMock()
+
+    def _client(name: str, **_kwargs):
+        if name == "s3":
+            return mock_s3
+        if name == "bedrock-agent":
+            return mock_bedrock
+        raise AssertionError(name)
+
+    mock_boto_client.side_effect = _client
+
+    env = {
+        "AWS_REGION": "us-gov-west-1",
+        "GITHUB_API_BASE": "https://api.github.com",
+        "GITHUB_APP_IDS_SECRET_ARN": "arn:ids",
+        "GITHUB_APP_PRIVATE_KEY_SECRET_ARN": "arn:key",
+        "BEDROCK_KNOWLEDGE_BASE_ID": "kb-1",
+        "BEDROCK_KB_DATA_SOURCE_ID": "ds-1",
+        "KB_SYNC_BUCKET": "bucket-1",
+        "GITHUB_KB_REPOS": "org/repo",
+        "GITHUB_KB_INCLUDE_PATTERNS": "README.md",
+    }
+
+    with patch.dict("os.environ", env, clear=False):
+        out = lambda_handler({}, None)
+
+    assert out["uploaded"] == 0
+    assert out["ingestion_job_id"] == ""
+    mock_bedrock.start_ingestion_job.assert_not_called()


### PR DESCRIPTION
## Summary
- add new GitHub docs KB sync lambda (src/github_kb_sync/app.py)
- extend GitHub client with repo metadata + recursive file listing helpers
- add Terraform vars/resources/outputs for scheduled GitHub docs sync
- update docs + helper scripts for Confluence/GitHub KB sync operations
- add tests for GitHub KB sync and new GitHub client methods

## Validation
- python -m ruff check src tests scripts
- python -m pytest -q tests/test_github_client.py tests/test_github_kb_sync.py
- terraform fmt -check

## Notes
- terraform validate remains environment-dependent (requires terraform init and Terraform >= 1.6)