### PR TITLE
feat(chatbot): add optional live GitHub lookup mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ Chatbot endpoint:
   - `confluence_cql` (optional)
   - `retrieval_mode` (optional: `live|kb|hybrid`; defaults to `hybrid`)
 
+Optional live GitHub lookup (disabled by default):
+
+- `chatbot_github_live_enabled=true`
+- `chatbot_github_live_repos=["owner/repo", ...]`
+- `chatbot_github_live_max_results=3`
+
+When enabled, `live`/`hybrid` mode can include real-time GitHub code/doc snippets in chatbot context.
+
 Chatbot login/auth options (Terraform `chatbot_auth_mode`):
 
 - `token` (default): shared header tokens

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -458,6 +458,8 @@ resource "aws_iam_policy" "chatbot_policy" {
           aws_secretsmanager_secret.atlassian_credentials.arn,
           var.chatbot_enabled ? aws_secretsmanager_secret.chatbot_api_token[0].arn : "",
           var.chatbot_enabled && var.teams_adapter_enabled ? aws_secretsmanager_secret.teams_adapter_token[0].arn : "",
+          var.chatbot_enabled && var.chatbot_github_live_enabled ? aws_secretsmanager_secret.github_app_private_key_pem.arn : "",
+          var.chatbot_enabled && var.chatbot_github_live_enabled ? aws_secretsmanager_secret.github_app_ids.arn : "",
         ])
       },
       {
@@ -662,14 +664,20 @@ resource "aws_lambda_function" "jira_confluence_chatbot" {
 
   environment {
     variables = {
-      AWS_REGION                       = "us-gov-west-1"
-      CHATBOT_MODEL_ID                 = var.chatbot_model_id
-      BEDROCK_MODEL_ID                 = var.bedrock_model_id
-      CHATBOT_RETRIEVAL_MODE           = var.chatbot_retrieval_mode
-      BEDROCK_KNOWLEDGE_BASE_ID        = var.bedrock_knowledge_base_id
-      BEDROCK_KB_TOP_K                 = tostring(var.bedrock_kb_top_k)
-      ATLASSIAN_CREDENTIALS_SECRET_ARN = aws_secretsmanager_secret.atlassian_credentials.arn
-      CHATBOT_API_TOKEN_SECRET_ARN     = var.chatbot_enabled ? aws_secretsmanager_secret.chatbot_api_token[0].arn : ""
+      AWS_REGION                        = "us-gov-west-1"
+      CHATBOT_MODEL_ID                  = var.chatbot_model_id
+      BEDROCK_MODEL_ID                  = var.bedrock_model_id
+      CHATBOT_RETRIEVAL_MODE            = var.chatbot_retrieval_mode
+      BEDROCK_KNOWLEDGE_BASE_ID         = var.bedrock_knowledge_base_id
+      BEDROCK_KB_TOP_K                  = tostring(var.bedrock_kb_top_k)
+      ATLASSIAN_CREDENTIALS_SECRET_ARN  = aws_secretsmanager_secret.atlassian_credentials.arn
+      CHATBOT_API_TOKEN_SECRET_ARN      = var.chatbot_enabled ? aws_secretsmanager_secret.chatbot_api_token[0].arn : ""
+      GITHUB_CHAT_LIVE_ENABLED          = tostring(var.chatbot_github_live_enabled)
+      GITHUB_CHAT_REPOS                 = join(",", var.chatbot_github_live_repos)
+      GITHUB_CHAT_MAX_RESULTS           = tostring(var.chatbot_github_live_max_results)
+      GITHUB_API_BASE                   = var.github_api_base
+      GITHUB_APP_PRIVATE_KEY_SECRET_ARN = var.chatbot_github_live_enabled ? aws_secretsmanager_secret.github_app_private_key_pem.arn : ""
+      GITHUB_APP_IDS_SECRET_ARN         = var.chatbot_github_live_enabled ? aws_secretsmanager_secret.github_app_ids.arn : ""
     }
   }
 }

--- a/infra/terraform/terraform.nonprod.tfvars.example
+++ b/infra/terraform/terraform.nonprod.tfvars.example
@@ -25,6 +25,9 @@ review_comment_mode   = "inline_best_effort"
 chatbot_enabled         = true
 chatbot_model_id        = "anthropic.claude-3-sonnet-20240229-v1:0"
 chatbot_retrieval_mode  = "hybrid"
+chatbot_github_live_enabled = false
+chatbot_github_live_repos = ["my-org/my-repo"]
+chatbot_github_live_max_results = 3
 bedrock_knowledge_base_id = "<SET_KB_ID>"
 bedrock_kb_top_k        = 5
 

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -29,6 +29,9 @@ review_comment_mode   = "inline_best_effort"
 chatbot_enabled = true
 chatbot_model_id = "anthropic.claude-3-sonnet-20240229-v1:0"
 chatbot_retrieval_mode = "hybrid"
+chatbot_github_live_enabled = false
+chatbot_github_live_repos = []
+chatbot_github_live_max_results = 3
 bedrock_knowledge_base_id = ""
 bedrock_kb_top_k = 5
 

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -104,6 +104,29 @@ variable "chatbot_retrieval_mode" {
   }
 }
 
+variable "chatbot_github_live_enabled" {
+  description = "Enable optional live GitHub code/doc lookup during chatbot live/hybrid fallback mode"
+  type        = bool
+  default     = false
+}
+
+variable "chatbot_github_live_repos" {
+  description = "Repositories (owner/repo) allowed for optional live GitHub chatbot lookup"
+  type        = list(string)
+  default     = []
+}
+
+variable "chatbot_github_live_max_results" {
+  description = "Maximum live GitHub search results used per chatbot query"
+  type        = number
+  default     = 3
+
+  validation {
+    condition     = var.chatbot_github_live_max_results >= 1
+    error_message = "Must be at least 1."
+  }
+}
+
 variable "bedrock_knowledge_base_id" {
   description = "Optional Bedrock Knowledge Base ID used by chatbot and sync jobs"
   type        = string

--- a/src/shared/github_client.py
+++ b/src/shared/github_client.py
@@ -47,6 +47,14 @@ class GitHubClient:
         response = self._request("GET", f"/repos/{owner}/{repo}/pulls/{pull_number}")
         return response.json()
 
+    def search_code(self, query: str, per_page: int = 10) -> list[dict]:
+        response = self._request(
+            "GET",
+            "/search/code",
+            params={"q": query, "per_page": per_page},
+        )
+        return response.json().get("items", [])
+
     def get_repository(self, owner: str, repo: str) -> dict:
         response = self._request("GET", f"/repos/{owner}/{repo}")
         return response.json()

--- a/tests/test_github_client.py
+++ b/tests/test_github_client.py
@@ -58,6 +58,8 @@ class FakeSession:
                 "commits": [{"sha": "aaa"}, {"sha": "bbb"}],
                 "files": [{"filename": "f.py"}],
             })
+        if url.endswith("/search/code"):
+            return FakeResponse(200, {"items": [{"path": "docs/guide.md", "repository": {"full_name": "o/r"}}]})
         if "/tags" in url:
             return FakeResponse(200, [{"name": "v2.0"}, {"name": "v1.5"}, {"name": "v1.0"}])
         if url.endswith("/releases") and method == "POST":
@@ -113,6 +115,14 @@ def test_compare_commits() -> None:
     client = GitHubClient(token_provider=lambda: "tok", session=session)
     result = client.compare_commits("o", "r", "v1.0", "v2.0")
     assert len(result["commits"]) == 2
+
+
+def test_search_code() -> None:
+    session = FakeSession()
+    client = GitHubClient(token_provider=lambda: "tok", session=session)
+    items = client.search_code("repo:o/r docs", per_page=5)
+    assert len(items) == 1
+    assert items[0]["path"] == "docs/guide.md"
 
 
 def test_create_release() -> None:


### PR DESCRIPTION
## Summary
- add optional live GitHub lookup support in chatbot live/hybrid fallback mode
- keep feature disabled by default via Terraform vars
- wire chatbot lambda env and IAM secret access for GitHub app creds only when enabled
- add tests for chatbot helper path and GitHub client search method
- document config in README and tfvars examples

## Validation
- python -m ruff check src tests scripts
- python -m pytest -q tests/test_chatbot_helpers.py tests/test_github_client.py
- terraform fmt -check

## Notes
- terraform validate remains environment-dependent (requires terraform init and Terraform >= 1.6)