### PR TITLE
feat(chatbot): add web UI with optional GitHub login

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,40 @@ PR description generator endpoint:
 - `python scripts/trigger_kb_sync.py --function-name <kb_sync_function_name>`
 - `python scripts/predeploy_nonprod_checks.py --tfvars infra/terraform/terraform.tfvars`
 
+### Small local web app (chatbot UI)
+
+This repository now includes a tiny browser UI for querying the chatbot API:
+
+- `webapp/index.html`
+- `webapp/app.js`
+- `webapp/styles.css`
+
+Run it locally:
+
+- `python scripts/run_chatbot_webapp.py --port 8080`
+
+Then open:
+
+- `http://localhost:8080`
+
+In the UI, provide:
+
+- Chatbot URL (`chatbot_url` Terraform output)
+- Auth mode (`token`, `bearer`, or `none`)
+- Auth value (API token or bearer token)
+
+Optional GitHub login in web app:
+
+- Expand **GitHub Login (device flow, optional)**
+- Set **GitHub OAuth Base URL** (`https://github.com` for github.com, or your GHES host)
+- Enter your GitHub OAuth App Client ID
+- Click **Login with GitHub** and complete verification on GitHub
+- The app will auto-fill `bearer` auth mode/token for chatbot calls
+
+If your environment blocks browser calls to GitHub OAuth endpoints, use manual `bearer` mode and paste a token.
+
+> Note: if your API Gateway CORS policy does not allow `http://localhost:8080`, browser requests may fail until CORS is enabled for that origin.
+
 > Note: local invokes still expect AWS credentials/resources for full path behavior unless mocked.
 
 Non-prod rollout checklist for KB mode and scheduled sync:

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -5,7 +5,8 @@
 - Stabilize and deploy hybrid Jira/Confluence + Bedrock Knowledge Base chatbot retrieval.
 - Enable scheduled Confluence sync into Bedrock Knowledge Base data source.
 - Keep existing PR-review and Teams adapter behavior backward compatible.
+- Provide an easy web chatbot access path with optional GitHub login for bearer auth.
 
 ## Current Blockers
 
-- None currently; validate Bedrock KB IDs/data source IDs in target environment before deploy.
+- None currently; validate Bedrock KB IDs/data source IDs and GitHub OAuth app client configuration in target environment before deploy.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -9,6 +9,9 @@
 - [x] Add Terraform wiring for KB/chatbot mode/sync schedule and missing Atlassian secret resource
 - [x] Add tests for KB client, chatbot mode routing/fallback, and sync document normalization
 - [x] Pass lint and unit tests (`ruff`, `pytest`)
+- [x] Add small local chatbot webapp (`webapp/*`, `scripts/run_chatbot_webapp.py`)
+- [x] Add optional GitHub login (OAuth device flow) in webapp with bearer auto-fill
+- [x] Verify test suite after webapp/auth UX updates (`169 passed`)
 
 ## Doing
 
@@ -17,3 +20,4 @@
 ## Next
 
 - [ ] Deploy Terraform changes to non-prod and verify scheduled sync + chatbot source telemetry
+- [ ] Validate GitHub OAuth app settings (client ID / scopes / allowed orgs) in non-prod chatbot flow

--- a/scripts/run_chatbot_webapp.py
+++ b/scripts/run_chatbot_webapp.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import http.server
+import socketserver
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run local static webapp for chatbot UI")
+    parser.add_argument("--port", type=int, default=8080, help="Local port to serve webapp")
+    parser.add_argument(
+        "--dir",
+        default="webapp",
+        help="Directory to serve (defaults to webapp)",
+    )
+    args = parser.parse_args()
+
+    root = Path(args.dir)
+    if not root.exists() or not root.is_dir():
+        raise SystemExit(f"Directory not found: {root}")
+
+    handler = http.server.SimpleHTTPRequestHandler
+    with socketserver.TCPServer(("", args.port), handler) as httpd:
+        print(f"Serving {root.resolve()} on http://localhost:{args.port}")
+        print("Press Ctrl+C to stop")
+        try:
+            import os
+
+            os.chdir(root)
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            pass
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/webapp/app.js
+++ b/webapp/app.js
@@ -1,0 +1,265 @@
+const ids = {
+  chatbotUrl: document.getElementById("chatbotUrl"),
+  authMode: document.getElementById("authMode"),
+  authValue: document.getElementById("authValue"),
+  retrievalMode: document.getElementById("retrievalMode"),
+  query: document.getElementById("query"),
+  jiraJql: document.getElementById("jiraJql"),
+  confluenceCql: document.getElementById("confluenceCql"),
+  githubOauthBaseUrl: document.getElementById("githubOauthBaseUrl"),
+  githubClientId: document.getElementById("githubClientId"),
+  githubScope: document.getElementById("githubScope"),
+  githubLoginBtn: document.getElementById("githubLoginBtn"),
+  githubLoginStatus: document.getElementById("githubLoginStatus"),
+  status: document.getElementById("status"),
+  answer: document.getElementById("answer"),
+  sources: document.getElementById("sources"),
+  sendBtn: document.getElementById("sendBtn"),
+  saveBtn: document.getElementById("saveBtn"),
+};
+
+const SETTINGS_KEY = "chatbot-webapp-settings-v1";
+
+function setStatus(message, kind = "muted") {
+  ids.status.className = `status ${kind}`;
+  ids.status.textContent = message;
+}
+
+function loadSettings() {
+  try {
+    const raw = localStorage.getItem(SETTINGS_KEY);
+    if (!raw) return;
+    const s = JSON.parse(raw);
+    ids.chatbotUrl.value = s.chatbotUrl || "";
+    ids.authMode.value = s.authMode || "token";
+    ids.authValue.value = s.authValue || "";
+    ids.retrievalMode.value = s.retrievalMode || "hybrid";
+    ids.jiraJql.value = s.jiraJql || "";
+    ids.confluenceCql.value = s.confluenceCql || "";
+    ids.githubOauthBaseUrl.value = s.githubOauthBaseUrl || "https://github.com";
+    ids.githubClientId.value = s.githubClientId || "";
+    ids.githubScope.value = s.githubScope || "read:user read:org";
+  } catch {
+    setStatus("Could not load saved settings.", "err");
+  }
+}
+
+function saveSettings() {
+  const s = {
+    chatbotUrl: ids.chatbotUrl.value.trim(),
+    authMode: ids.authMode.value,
+    authValue: ids.authValue.value,
+    retrievalMode: ids.retrievalMode.value,
+    jiraJql: ids.jiraJql.value.trim(),
+    confluenceCql: ids.confluenceCql.value.trim(),
+    githubOauthBaseUrl: ids.githubOauthBaseUrl.value.trim() || "https://github.com",
+    githubClientId: ids.githubClientId.value.trim(),
+    githubScope: ids.githubScope.value.trim() || "read:user read:org",
+  };
+  localStorage.setItem(SETTINGS_KEY, JSON.stringify(s));
+  setStatus("Settings saved locally.", "ok");
+}
+
+function setGitHubLoginStatus(message, kind = "muted") {
+  ids.githubLoginStatus.className = `status ${kind}`;
+  ids.githubLoginStatus.textContent = message;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function startGitHubLogin() {
+  const oauthBase = (ids.githubOauthBaseUrl.value.trim() || "https://github.com").replace(/\/$/, "");
+  const clientId = ids.githubClientId.value.trim();
+  const scope = ids.githubScope.value.trim() || "read:user read:org";
+
+  if (!/^https:\/\//i.test(oauthBase)) {
+    setGitHubLoginStatus("GitHub OAuth Base URL must start with https://", "err");
+    return;
+  }
+
+  if (!clientId) {
+    setGitHubLoginStatus("Enter a GitHub OAuth Client ID first.", "err");
+    return;
+  }
+
+  ids.githubLoginBtn.disabled = true;
+  setGitHubLoginStatus("Requesting device code from GitHub...", "muted");
+
+  let deviceCode = "";
+  let interval = 5;
+  let expiresAt = Date.now() + 10 * 60 * 1000;
+
+  try {
+    const body = new URLSearchParams({ client_id: clientId, scope });
+    const deviceRes = await fetch(`${oauthBase}/login/device/code`, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body,
+    });
+
+    const deviceData = await deviceRes.json();
+    if (!deviceRes.ok || !deviceData.device_code) {
+      const msg = deviceData.error_description || deviceData.error || `HTTP ${deviceRes.status}`;
+      setGitHubLoginStatus(`GitHub login start failed: ${msg}`, "err");
+      return;
+    }
+
+    deviceCode = String(deviceData.device_code);
+    interval = Number(deviceData.interval || 5);
+    expiresAt = Date.now() + Number(deviceData.expires_in || 900) * 1000;
+
+    const verifyUri = String(deviceData.verification_uri || `${oauthBase}/login/device`);
+    const userCode = String(deviceData.user_code || "");
+    setGitHubLoginStatus(`Open ${verifyUri} and enter code: ${userCode}`, "ok");
+    window.open(verifyUri, "_blank", "noopener,noreferrer");
+  } catch (err) {
+    setGitHubLoginStatus(`Could not start GitHub login: ${String(err)}`, "err");
+    ids.githubLoginBtn.disabled = false;
+    return;
+  }
+
+  try {
+    while (Date.now() < expiresAt) {
+      await sleep(interval * 1000);
+
+      const pollBody = new URLSearchParams({
+        client_id: clientId,
+        device_code: deviceCode,
+        grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+      });
+
+      const tokenRes = await fetch(`${oauthBase}/login/oauth/access_token`, {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: pollBody,
+      });
+      const tokenData = await tokenRes.json().catch(() => ({}));
+
+      if (tokenData.access_token) {
+        ids.authMode.value = "bearer";
+        ids.authValue.value = String(tokenData.access_token);
+        saveSettings();
+        setGitHubLoginStatus("GitHub login complete. Bearer token populated.", "ok");
+        setStatus("GitHub login complete. Ready to query chatbot.", "ok");
+        return;
+      }
+
+      const error = String(tokenData.error || "");
+      if (error === "authorization_pending") {
+        setGitHubLoginStatus("Waiting for GitHub authorization...", "muted");
+        continue;
+      }
+      if (error === "slow_down") {
+        interval += 5;
+        setGitHubLoginStatus("GitHub asked to slow down polling...", "muted");
+        continue;
+      }
+      if (error === "expired_token") {
+        setGitHubLoginStatus("GitHub device code expired. Start login again.", "err");
+        return;
+      }
+      if (error === "access_denied") {
+        setGitHubLoginStatus("GitHub login cancelled/denied.", "err");
+        return;
+      }
+
+      const msg = tokenData.error_description || tokenData.error || `HTTP ${tokenRes.status}`;
+      setGitHubLoginStatus(`GitHub login failed: ${msg}`, "err");
+      return;
+    }
+
+    setGitHubLoginStatus("Login timed out. Start GitHub login again.", "err");
+  } catch (err) {
+    setGitHubLoginStatus(`GitHub login failed: ${String(err)}`, "err");
+  } finally {
+    ids.githubLoginBtn.disabled = false;
+  }
+}
+
+function buildHeaders() {
+  const headers = { "Content-Type": "application/json" };
+  const authMode = ids.authMode.value;
+  const authValue = ids.authValue.value.trim();
+
+  if (!authValue || authMode === "none") return headers;
+  if (authMode === "token") headers["X-Api-Token"] = authValue;
+  if (authMode === "bearer") headers.Authorization = `Bearer ${authValue}`;
+  return headers;
+}
+
+function renderSources(sources = {}) {
+  const entries = Object.entries(sources)
+    .map(([k, v]) => `<strong>${k}</strong>: ${String(v)}`)
+    .join(" · ");
+  ids.sources.innerHTML = entries || "";
+}
+
+async function askChatbot() {
+  const endpoint = ids.chatbotUrl.value.trim();
+  const query = ids.query.value.trim();
+
+  if (!endpoint) {
+    setStatus("Enter chatbot URL first.", "err");
+    return;
+  }
+  if (!query) {
+    setStatus("Enter a query first.", "err");
+    return;
+  }
+
+  saveSettings();
+  ids.sendBtn.disabled = true;
+  setStatus("Sending request...", "muted");
+
+  const payload = {
+    query,
+    retrieval_mode: ids.retrievalMode.value,
+  };
+
+  const jiraJql = ids.jiraJql.value.trim();
+  const confluenceCql = ids.confluenceCql.value.trim();
+  if (jiraJql) payload.jira_jql = jiraJql;
+  if (confluenceCql) payload.confluence_cql = confluenceCql;
+
+  try {
+    const res = await fetch(endpoint, {
+      method: "POST",
+      headers: buildHeaders(),
+      body: JSON.stringify(payload),
+    });
+
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      ids.answer.textContent = JSON.stringify(body, null, 2) || `HTTP ${res.status}`;
+      renderSources({});
+      setStatus(`Request failed (${res.status}).`, "err");
+      return;
+    }
+
+    ids.answer.textContent = body.answer || JSON.stringify(body, null, 2);
+    renderSources(body.sources || {});
+    setStatus("Response received.", "ok");
+  } catch (err) {
+    ids.answer.textContent = String(err);
+    renderSources({});
+    setStatus("Network/CORS error. Check API URL and auth mode.", "err");
+  } finally {
+    ids.sendBtn.disabled = false;
+  }
+}
+
+ids.saveBtn.addEventListener("click", saveSettings);
+ids.sendBtn.addEventListener("click", askChatbot);
+ids.githubLoginBtn.addEventListener("click", startGitHubLogin);
+
+loadSettings();
+setStatus("Ready.");
+setGitHubLoginStatus("Not started.");

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI Chatbot Console</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <h1>AI Chatbot Console</h1>
+      <p class="subtitle">Small internal web client for <code>/chatbot/query</code>.</p>
+
+      <section class="panel">
+        <h2>Connection</h2>
+        <div class="grid two">
+          <label>
+            Chatbot URL
+            <input id="chatbotUrl" placeholder="https://.../chatbot/query" />
+          </label>
+          <label>
+            Auth Mode
+            <select id="authMode">
+              <option value="token">token (X-Api-Token)</option>
+              <option value="bearer">bearer (JWT / GitHub OAuth)</option>
+              <option value="none">none</option>
+            </select>
+          </label>
+          <label>
+            Auth Value
+            <input id="authValue" type="password" placeholder="token or bearer jwt" />
+          </label>
+          <label>
+            Retrieval Mode
+            <select id="retrievalMode">
+              <option value="hybrid">hybrid</option>
+              <option value="kb">kb</option>
+              <option value="live">live</option>
+            </select>
+          </label>
+        </div>
+        <details class="gh-login" id="ghLoginPanel">
+          <summary>GitHub Login (device flow, optional)</summary>
+          <p class="muted small">
+            Use a GitHub OAuth App client ID to sign in and auto-fill bearer auth. If your browser blocks this flow, use manual bearer token mode.
+          </p>
+          <div class="grid two">
+            <label>
+              GitHub OAuth Base URL
+              <input id="githubOauthBaseUrl" value="https://github.com" />
+            </label>
+            <label>
+              GitHub OAuth Client ID
+              <input id="githubClientId" placeholder="Iv1.0123456789abcdef" />
+            </label>
+            <label>
+              GitHub Scope
+              <input id="githubScope" value="read:user read:org" />
+            </label>
+          </div>
+          <div class="actions">
+            <button id="githubLoginBtn" type="button">Login with GitHub</button>
+          </div>
+          <div id="githubLoginStatus" class="status muted">Not started.</div>
+        </details>
+      </section>
+
+      <section class="panel">
+        <h2>Prompt</h2>
+        <div class="grid one">
+          <label>
+            Query
+            <textarea id="query" rows="4" placeholder="Ask about Jira, Confluence, or indexed GitHub docs..."></textarea>
+          </label>
+          <div class="grid two">
+            <label>
+              Jira JQL (optional)
+              <input id="jiraJql" placeholder="project=PLAT order by updated DESC" />
+            </label>
+            <label>
+              Confluence CQL (optional)
+              <input id="confluenceCql" placeholder="type=page order by lastmodified desc" />
+            </label>
+          </div>
+        </div>
+        <div class="actions">
+          <button id="saveBtn" type="button">Save Settings</button>
+          <button id="sendBtn" type="button">Ask Chatbot</button>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h2>Response</h2>
+        <div id="status" class="status muted">Ready.</div>
+        <pre id="answer" class="answer">No response yet.</pre>
+        <div id="sources" class="sources"></div>
+      </section>
+    </main>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/webapp/styles.css
+++ b/webapp/styles.css
@@ -1,0 +1,142 @@
+:root {
+  color-scheme: dark;
+  --bg: #0f172a;
+  --panel: #111827;
+  --panel-border: #1f2937;
+  --text: #e5e7eb;
+  --muted: #9ca3af;
+  --accent: #60a5fa;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: linear-gradient(180deg, #0b1224 0%, var(--bg) 100%);
+  color: var(--text);
+}
+
+.container {
+  max-width: 980px;
+  margin: 24px auto;
+  padding: 0 16px 32px;
+}
+
+h1 {
+  margin-bottom: 4px;
+}
+
+.subtitle {
+  margin-top: 0;
+  color: var(--muted);
+}
+
+.panel {
+  background: color-mix(in hsl, var(--panel), black 8%);
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+  padding: 14px;
+  margin-top: 14px;
+}
+
+.small {
+  font-size: 0.86rem;
+}
+
+.gh-login {
+  margin-top: 12px;
+  border-top: 1px solid #1e293b;
+  padding-top: 10px;
+}
+
+.gh-login summary {
+  cursor: pointer;
+  color: #cbd5e1;
+  margin-bottom: 8px;
+}
+
+.grid {
+  display: grid;
+  gap: 12px;
+}
+
+.grid.two {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+label {
+  display: grid;
+  gap: 6px;
+  font-size: 0.92rem;
+  color: #cbd5e1;
+}
+
+input,
+select,
+textarea,
+button {
+  border-radius: 8px;
+  border: 1px solid #334155;
+  background: #0b1220;
+  color: var(--text);
+  padding: 10px;
+  font: inherit;
+}
+
+textarea {
+  resize: vertical;
+}
+
+.actions {
+  margin-top: 10px;
+  display: flex;
+  gap: 10px;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:hover {
+  border-color: var(--accent);
+}
+
+.status {
+  padding: 8px;
+  border-radius: 8px;
+  margin-bottom: 8px;
+  font-size: 0.92rem;
+}
+
+.status.ok {
+  background: #064e3b;
+  border: 1px solid #065f46;
+}
+
+.status.err {
+  background: #7f1d1d;
+  border: 1px solid #991b1b;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.answer {
+  margin: 0;
+  white-space: pre-wrap;
+  background: #0b1220;
+  border: 1px solid #1e293b;
+  border-radius: 8px;
+  padding: 12px;
+  min-height: 80px;
+}
+
+.sources {
+  margin-top: 10px;
+  color: #cbd5e1;
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
## Summary
- add a small local static webapp for the chatbot query endpoint
- add optional GitHub OAuth device-flow login that auto-fills bearer auth
- support configurable GitHub OAuth base URL (github.com or GHES host)
- document local webapp usage and GitHub login flow in README

## Validation
- python -m ruff check src tests scripts
- python -m pytest -q