### PR TITLE
fix(chatbot): enforce NG-hosted GitHub OAuth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ In the UI, provide:
 Optional GitHub login in web app:
 
 - Expand **GitHub Login (device flow, optional)**
-- Set **GitHub OAuth Base URL** (`https://github.com` for github.com, or your GHES host)
+- Set **GitHub OAuth Base URL** to your **NG-hosted GitHub** base URL (GHES host)
 - Enter your GitHub OAuth App Client ID
 - Click **Login with GitHub** and complete verification on GitHub
 - The app will auto-fill `bearer` auth mode/token for chatbot calls

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -6,7 +6,8 @@
 - Enable scheduled Confluence sync into Bedrock Knowledge Base data source.
 - Keep existing PR-review and Teams adapter behavior backward compatible.
 - Provide an easy web chatbot access path with optional GitHub login for bearer auth.
+- Enforce NG-hosted GitHub OAuth endpoint usage in the chatbot web login flow.
 
 ## Current Blockers
 
-- None currently; validate Bedrock KB IDs/data source IDs and GitHub OAuth app client configuration in target environment before deploy.
+- None currently; validate Bedrock KB IDs/data source IDs and NG-hosted GitHub OAuth app client configuration in target environment before deploy.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -11,6 +11,7 @@
 - [x] Pass lint and unit tests (`ruff`, `pytest`)
 - [x] Add small local chatbot webapp (`webapp/*`, `scripts/run_chatbot_webapp.py`)
 - [x] Add optional GitHub login (OAuth device flow) in webapp with bearer auto-fill
+- [x] Enforce NG-hosted GitHub OAuth base URL in webapp login flow
 - [x] Verify test suite after webapp/auth UX updates (`169 passed`)
 
 ## Doing

--- a/webapp/app.js
+++ b/webapp/app.js
@@ -36,7 +36,7 @@ function loadSettings() {
     ids.retrievalMode.value = s.retrievalMode || "hybrid";
     ids.jiraJql.value = s.jiraJql || "";
     ids.confluenceCql.value = s.confluenceCql || "";
-    ids.githubOauthBaseUrl.value = s.githubOauthBaseUrl || "https://github.com";
+    ids.githubOauthBaseUrl.value = s.githubOauthBaseUrl || "";
     ids.githubClientId.value = s.githubClientId || "";
     ids.githubScope.value = s.githubScope || "read:user read:org";
   } catch {
@@ -52,7 +52,7 @@ function saveSettings() {
     retrievalMode: ids.retrievalMode.value,
     jiraJql: ids.jiraJql.value.trim(),
     confluenceCql: ids.confluenceCql.value.trim(),
-    githubOauthBaseUrl: ids.githubOauthBaseUrl.value.trim() || "https://github.com",
+    githubOauthBaseUrl: ids.githubOauthBaseUrl.value.trim(),
     githubClientId: ids.githubClientId.value.trim(),
     githubScope: ids.githubScope.value.trim() || "read:user read:org",
   };
@@ -70,12 +70,22 @@ function sleep(ms) {
 }
 
 async function startGitHubLogin() {
-  const oauthBase = (ids.githubOauthBaseUrl.value.trim() || "https://github.com").replace(/\/$/, "");
+  const oauthBase = ids.githubOauthBaseUrl.value.trim().replace(/\/$/, "");
   const clientId = ids.githubClientId.value.trim();
   const scope = ids.githubScope.value.trim() || "read:user read:org";
 
+  if (!oauthBase) {
+    setGitHubLoginStatus("Set GitHub OAuth Base URL to your NG-hosted GitHub URL.", "err");
+    return;
+  }
+
   if (!/^https:\/\//i.test(oauthBase)) {
     setGitHubLoginStatus("GitHub OAuth Base URL must start with https://", "err");
+    return;
+  }
+
+  if (/^https:\/\/github\.com$/i.test(oauthBase)) {
+    setGitHubLoginStatus("Use your NG-hosted GitHub URL (github.com is not allowed in this environment).", "err");
     return;
   }
 

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -42,12 +42,12 @@
         <details class="gh-login" id="ghLoginPanel">
           <summary>GitHub Login (device flow, optional)</summary>
           <p class="muted small">
-            Use a GitHub OAuth App client ID to sign in and auto-fill bearer auth. If your browser blocks this flow, use manual bearer token mode.
+            Use an NG-hosted GitHub OAuth App client ID to sign in and auto-fill bearer auth. If your browser blocks this flow, use manual bearer token mode.
           </p>
           <div class="grid two">
             <label>
               GitHub OAuth Base URL
-              <input id="githubOauthBaseUrl" value="https://github.com" />
+              <input id="githubOauthBaseUrl" placeholder="https://github.<your-ng-domain>" />
             </label>
             <label>
               GitHub OAuth Client ID


### PR DESCRIPTION
## Summary
- require a configured NG-hosted GitHub OAuth base URL in webapp login flow
- block public github.com base URL for this environment
- update README and memory notes to reflect NG-hosted GitHub requirement

## Validation
- python -m ruff check src tests scripts
- python -m pytest -q