### PR TITLE
chore(docs): replace NG wording with enterprise hosted

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ In the UI, provide:
 Optional GitHub login in web app:
 
 - Expand **GitHub Login (device flow, optional)**
-- Set **GitHub OAuth Base URL** to your **NG-hosted GitHub** base URL (GHES host)
+- Set **GitHub OAuth Base URL** to your **enterprise hosted GitHub** base URL (GHES host)
 - Enter your GitHub OAuth App Client ID
 - Click **Login with GitHub** and complete verification on GitHub
 - The app will auto-fill `bearer` auth mode/token for chatbot calls

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -6,8 +6,8 @@
 - Enable scheduled Confluence sync into Bedrock Knowledge Base data source.
 - Keep existing PR-review and Teams adapter behavior backward compatible.
 - Provide an easy web chatbot access path with optional GitHub login for bearer auth.
-- Enforce NG-hosted GitHub OAuth endpoint usage in the chatbot web login flow.
+- Enforce enterprise hosted GitHub OAuth endpoint usage in the chatbot web login flow.
 
 ## Current Blockers
 
-- None currently; validate Bedrock KB IDs/data source IDs and NG-hosted GitHub OAuth app client configuration in target environment before deploy.
+- None currently; validate Bedrock KB IDs/data source IDs and enterprise hosted GitHub OAuth app client configuration in target environment before deploy.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -11,7 +11,7 @@
 - [x] Pass lint and unit tests (`ruff`, `pytest`)
 - [x] Add small local chatbot webapp (`webapp/*`, `scripts/run_chatbot_webapp.py`)
 - [x] Add optional GitHub login (OAuth device flow) in webapp with bearer auto-fill
-- [x] Enforce NG-hosted GitHub OAuth base URL in webapp login flow
+- [x] Enforce enterprise hosted GitHub OAuth base URL in webapp login flow
 - [x] Verify test suite after webapp/auth UX updates (`169 passed`)
 
 ## Doing

--- a/webapp/app.js
+++ b/webapp/app.js
@@ -75,7 +75,7 @@ async function startGitHubLogin() {
   const scope = ids.githubScope.value.trim() || "read:user read:org";
 
   if (!oauthBase) {
-    setGitHubLoginStatus("Set GitHub OAuth Base URL to your NG-hosted GitHub URL.", "err");
+    setGitHubLoginStatus("Set GitHub OAuth Base URL to your enterprise hosted GitHub URL.", "err");
     return;
   }
 
@@ -85,7 +85,7 @@ async function startGitHubLogin() {
   }
 
   if (/^https:\/\/github\.com$/i.test(oauthBase)) {
-    setGitHubLoginStatus("Use your NG-hosted GitHub URL (github.com is not allowed in this environment).", "err");
+    setGitHubLoginStatus("Use your enterprise hosted GitHub URL (github.com is not allowed in this environment).", "err");
     return;
   }
 

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -42,12 +42,12 @@
         <details class="gh-login" id="ghLoginPanel">
           <summary>GitHub Login (device flow, optional)</summary>
           <p class="muted small">
-            Use an NG-hosted GitHub OAuth App client ID to sign in and auto-fill bearer auth. If your browser blocks this flow, use manual bearer token mode.
+            Use an enterprise hosted GitHub OAuth App client ID to sign in and auto-fill bearer auth. If your browser blocks this flow, use manual bearer token mode.
           </p>
           <div class="grid two">
             <label>
               GitHub OAuth Base URL
-              <input id="githubOauthBaseUrl" placeholder="https://github.<your-ng-domain>" />
+              <input id="githubOauthBaseUrl" placeholder="https://github.<your-enterprise-domain>" />
             </label>
             <label>
               GitHub OAuth Client ID


### PR DESCRIPTION
## Summary
- replace NG wording with enterprise hosted terminology in chatbot webapp copy
- update README enterprise-hosted wording for GitHub OAuth guidance
- align memory-bank context/progress notes with enterprise hosted terminology

## Validation
- python -m pytest -q