### PR TITLE
feat(chatbot): add general chat mode and model/provider routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,34 @@ Chatbot endpoint:
 - `POST /chatbot/query`
 - JSON body:
   - `query` (required)
+  - `assistant_mode` (optional: `contextual|general`; defaults to `contextual`)
+  - `llm_provider` (optional: `bedrock|anthropic_direct`; defaults to `bedrock`)
+  - `model_id` (optional override; validated against allow-list when configured)
   - `jira_jql` (optional)
   - `confluence_cql` (optional)
   - `retrieval_mode` (optional: `live|kb|hybrid`; defaults to `hybrid`)
+
+Assistant mode behavior:
+
+- `contextual`: existing Jira/Confluence/KB/GitHub context-aware flow.
+- `general`: freeform AI chat (no Jira/Confluence/KB retrieval context).
+
+Provider behavior:
+
+- `bedrock`: uses Bedrock runtime and supports model override (including enabled Amazon-hosted Bedrock models).
+- `anthropic_direct`: optional direct Anthropic API path using your own API key.
+
+Anthropic direct configuration (optional):
+
+- `CHATBOT_ENABLE_ANTHROPIC_DIRECT=true`
+- `CHATBOT_ANTHROPIC_API_KEY` or `CHATBOT_ANTHROPIC_API_KEY_SECRET_ARN`
+- `CHATBOT_ANTHROPIC_MODEL_ID` (default when request does not supply `model_id`)
+- `CHATBOT_ANTHROPIC_API_BASE` (default `https://api.anthropic.com`)
+
+Bedrock model selection controls:
+
+- `CHATBOT_ALLOWED_MODEL_IDS` (CSV; optional allow-list for request `model_id`)
+- If unset, any model ID available to the account/region can be requested.
 
 Optional live GitHub lookup (disabled by default):
 
@@ -225,6 +250,9 @@ In the UI, provide:
 - Chatbot URL (`chatbot_url` Terraform output)
 - Auth mode (`token`, `bearer`, or `none`)
 - Auth value (API token or bearer token)
+- Assistant Mode (`contextual` or `general`)
+- LLM Provider (`bedrock` or `anthropic_direct`)
+- Optional Model ID override (for example Amazon-hosted Bedrock model IDs)
 
 Optional GitHub login in web app:
 

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -460,6 +460,7 @@ resource "aws_iam_policy" "chatbot_policy" {
           var.chatbot_enabled && var.teams_adapter_enabled ? aws_secretsmanager_secret.teams_adapter_token[0].arn : "",
           var.chatbot_enabled && var.chatbot_github_live_enabled ? aws_secretsmanager_secret.github_app_private_key_pem.arn : "",
           var.chatbot_enabled && var.chatbot_github_live_enabled ? aws_secretsmanager_secret.github_app_ids.arn : "",
+          var.chatbot_enabled && var.chatbot_enable_anthropic_direct && length(trimspace(var.chatbot_anthropic_api_key_secret_arn)) > 0 ? var.chatbot_anthropic_api_key_secret_arn : "",
         ])
       },
       {
@@ -668,6 +669,13 @@ resource "aws_lambda_function" "jira_confluence_chatbot" {
       CHATBOT_MODEL_ID                  = var.chatbot_model_id
       BEDROCK_MODEL_ID                  = var.bedrock_model_id
       CHATBOT_RETRIEVAL_MODE            = var.chatbot_retrieval_mode
+      CHATBOT_DEFAULT_ASSISTANT_MODE    = var.chatbot_default_assistant_mode
+      CHATBOT_LLM_PROVIDER              = var.chatbot_llm_provider
+      CHATBOT_ALLOWED_MODEL_IDS         = join(",", var.chatbot_allowed_model_ids)
+      CHATBOT_ENABLE_ANTHROPIC_DIRECT   = tostring(var.chatbot_enable_anthropic_direct)
+      CHATBOT_ANTHROPIC_API_KEY_SECRET_ARN = var.chatbot_anthropic_api_key_secret_arn
+      CHATBOT_ANTHROPIC_API_BASE        = var.chatbot_anthropic_api_base
+      CHATBOT_ANTHROPIC_MODEL_ID        = var.chatbot_anthropic_model_id
       BEDROCK_KNOWLEDGE_BASE_ID         = var.bedrock_knowledge_base_id
       BEDROCK_KB_TOP_K                  = tostring(var.bedrock_kb_top_k)
       ATLASSIAN_CREDENTIALS_SECRET_ARN  = aws_secretsmanager_secret.atlassian_credentials.arn

--- a/infra/terraform/terraform.nonprod.tfvars.example
+++ b/infra/terraform/terraform.nonprod.tfvars.example
@@ -25,6 +25,17 @@ review_comment_mode   = "inline_best_effort"
 chatbot_enabled         = true
 chatbot_model_id        = "anthropic.claude-3-sonnet-20240229-v1:0"
 chatbot_retrieval_mode  = "hybrid"
+chatbot_default_assistant_mode = "contextual"
+chatbot_llm_provider    = "bedrock"
+chatbot_allowed_model_ids = [
+  "anthropic.claude-3-7-sonnet-20250219-v1:0",
+  # "amazon.nova-lite-v1:0",
+  # "amazon.nova-pro-v1:0",
+]
+chatbot_enable_anthropic_direct = false
+chatbot_anthropic_api_key_secret_arn = ""
+chatbot_anthropic_api_base = "https://api.anthropic.com"
+chatbot_anthropic_model_id = "claude-sonnet-4-5"
 chatbot_github_live_enabled = false
 chatbot_github_live_repos = ["my-org/my-repo"]
 chatbot_github_live_max_results = 3

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -29,6 +29,17 @@ review_comment_mode   = "inline_best_effort"
 chatbot_enabled = true
 chatbot_model_id = "anthropic.claude-3-sonnet-20240229-v1:0"
 chatbot_retrieval_mode = "hybrid"
+chatbot_default_assistant_mode = "contextual"
+chatbot_llm_provider = "bedrock"
+chatbot_allowed_model_ids = [
+  # "amazon.nova-lite-v1:0",
+  # "amazon.nova-pro-v1:0",
+  # "anthropic.claude-3-7-sonnet-20250219-v1:0",
+]
+chatbot_enable_anthropic_direct = false
+chatbot_anthropic_api_key_secret_arn = ""
+chatbot_anthropic_api_base = "https://api.anthropic.com"
+chatbot_anthropic_model_id = "claude-sonnet-4-5"
 chatbot_github_live_enabled = false
 chatbot_github_live_repos = []
 chatbot_github_live_max_results = 3

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -104,6 +104,58 @@ variable "chatbot_retrieval_mode" {
   }
 }
 
+variable "chatbot_default_assistant_mode" {
+  description = "Default chatbot assistant mode: contextual or general"
+  type        = string
+  default     = "contextual"
+
+  validation {
+    condition     = contains(["contextual", "general"], var.chatbot_default_assistant_mode)
+    error_message = "Must be one of: contextual, general."
+  }
+}
+
+variable "chatbot_llm_provider" {
+  description = "Default chatbot LLM provider: bedrock or anthropic_direct"
+  type        = string
+  default     = "bedrock"
+
+  validation {
+    condition     = contains(["bedrock", "anthropic_direct"], var.chatbot_llm_provider)
+    error_message = "Must be one of: bedrock, anthropic_direct."
+  }
+}
+
+variable "chatbot_allowed_model_ids" {
+  description = "Optional allow-list of Bedrock model IDs that the chatbot may use when model_id override is supplied"
+  type        = list(string)
+  default     = []
+}
+
+variable "chatbot_enable_anthropic_direct" {
+  description = "Enable direct Anthropic API provider path in chatbot"
+  type        = bool
+  default     = false
+}
+
+variable "chatbot_anthropic_api_key_secret_arn" {
+  description = "Optional Secrets Manager ARN containing Anthropic API key for direct provider path"
+  type        = string
+  default     = ""
+}
+
+variable "chatbot_anthropic_api_base" {
+  description = "Base URL for direct Anthropic API provider"
+  type        = string
+  default     = "https://api.anthropic.com"
+}
+
+variable "chatbot_anthropic_model_id" {
+  description = "Default Anthropic direct model ID used when request model_id is not provided"
+  type        = string
+  default     = "claude-sonnet-4-5"
+}
+
 variable "chatbot_github_live_enabled" {
   description = "Enable optional live GitHub code/doc lookup during chatbot live/hybrid fallback mode"
   type        = bool

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -7,6 +7,8 @@
 - Keep existing PR-review and Teams adapter behavior backward compatible.
 - Provide an easy web chatbot access path with optional GitHub login for bearer auth.
 - Enforce enterprise hosted GitHub OAuth endpoint usage in the chatbot web login flow.
+- Support general AI chat mode and model/provider selection in chatbot requests.
+- Allow optional direct Anthropic provider while keeping Bedrock as default.
 
 ## Current Blockers
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -12,7 +12,12 @@
 - [x] Add small local chatbot webapp (`webapp/*`, `scripts/run_chatbot_webapp.py`)
 - [x] Add optional GitHub login (OAuth device flow) in webapp with bearer auto-fill
 - [x] Enforce enterprise hosted GitHub OAuth base URL in webapp login flow
-- [x] Verify test suite after webapp/auth UX updates (`169 passed`)
+- [x] Add chatbot `general` AI mode for freeform prompts (context retrieval optional)
+- [x] Add LLM provider routing (`bedrock` and optional `anthropic_direct`)
+- [x] Add optional request `model_id` override with Bedrock allow-list support
+- [x] Add webapp controls for assistant mode/provider/model override
+- [x] Add Terraform knobs for provider defaults and Anthropic direct configuration
+- [x] Verify test suite after chat/provider/model updates (`174 passed`)
 
 ## Doing
 

--- a/src/chatbot/app.py
+++ b/src/chatbot/app.py
@@ -9,6 +9,7 @@ from typing import Any
 import boto3
 
 from shared.atlassian_client import AtlassianClient
+from shared.anthropic_chat import AnthropicChatClient
 from shared.bedrock_chat import BedrockChatClient
 from shared.bedrock_kb import BedrockKnowledgeBaseClient
 from shared.constants import DEFAULT_REGION, MAX_QUERY_FILTER_LENGTH, MAX_QUERY_LENGTH
@@ -18,8 +19,11 @@ from shared.logging import get_logger
 
 logger = get_logger("jira_confluence_chatbot")
 ALLOWED_RETRIEVAL_MODES = {"live", "kb", "hybrid"}
+ALLOWED_ASSISTANT_MODES = {"contextual", "general"}
+ALLOWED_LLM_PROVIDERS = {"bedrock", "anthropic_direct"}
 
 _cached_api_token: str | None = None
+_cached_anthropic_api_key: str | None = None
 
 
 def _load_api_token() -> str:
@@ -47,6 +51,87 @@ def _validate_query_filter(value: str) -> bool:
         if marker in value:
             return False
     return True
+
+
+def _normalize_assistant_mode(value: str | None) -> str:
+    mode = (value or os.getenv("CHATBOT_DEFAULT_ASSISTANT_MODE", "contextual")).strip().lower()
+    if mode not in ALLOWED_ASSISTANT_MODES:
+        return "contextual"
+    return mode
+
+
+def _normalize_llm_provider(value: str | None) -> str:
+    provider = (value or os.getenv("CHATBOT_LLM_PROVIDER", "bedrock")).strip().lower()
+    if provider not in ALLOWED_LLM_PROVIDERS:
+        return "bedrock"
+    return provider
+
+
+def _allowed_bedrock_model_ids() -> set[str]:
+    raw = os.getenv("CHATBOT_ALLOWED_MODEL_IDS", "")
+    return {item.strip() for item in raw.split(",") if item.strip()}
+
+
+def _validate_bedrock_model_id(model_id: str) -> None:
+    if not model_id:
+        raise ValueError("model_id_required")
+    allowlist = _allowed_bedrock_model_ids()
+    if allowlist and model_id not in allowlist:
+        raise ValueError("model_not_allowed")
+
+
+def _load_anthropic_api_key() -> str:
+    global _cached_anthropic_api_key  # noqa: PLW0603
+    if _cached_anthropic_api_key is not None:
+        return _cached_anthropic_api_key
+
+    secret_arn = os.getenv("CHATBOT_ANTHROPIC_API_KEY_SECRET_ARN", "").strip()
+    if secret_arn:
+        client = boto3.client("secretsmanager")
+        resp = client.get_secret_value(SecretId=secret_arn)
+        _cached_anthropic_api_key = (resp.get("SecretString") or "").strip()
+    else:
+        _cached_anthropic_api_key = os.getenv("CHATBOT_ANTHROPIC_API_KEY", "").strip()
+
+    return _cached_anthropic_api_key
+
+
+def _resolve_model_id(provider: str, requested_model_id: str | None) -> str:
+    requested = (requested_model_id or "").strip()
+    if provider == "anthropic_direct":
+        return requested or os.getenv("CHATBOT_ANTHROPIC_MODEL_ID", "claude-sonnet-4-5")
+    return requested or os.getenv("CHATBOT_MODEL_ID", os.environ.get("BEDROCK_MODEL_ID", ""))
+
+
+def _answer_with_provider(
+    provider: str,
+    model_id: str,
+    system_prompt: str,
+    user_prompt: str,
+) -> str:
+    if provider == "anthropic_direct":
+        enabled = os.getenv("CHATBOT_ENABLE_ANTHROPIC_DIRECT", "false").strip().lower() == "true"
+        if not enabled:
+            raise ValueError("anthropic_direct_disabled")
+
+        api_key = _load_anthropic_api_key()
+        if not api_key:
+            raise ValueError("anthropic_api_key_missing")
+
+        client = AnthropicChatClient(
+            api_key=api_key,
+            model_id=model_id,
+            api_base=os.getenv("CHATBOT_ANTHROPIC_API_BASE", "https://api.anthropic.com"),
+            max_tokens=int(os.getenv("CHATBOT_MAX_TOKENS", "1200")),
+        )
+        return client.answer(system_prompt=system_prompt, user_prompt=user_prompt)
+
+    _validate_bedrock_model_id(model_id)
+    client = BedrockChatClient(
+        region=os.getenv("AWS_REGION", DEFAULT_REGION),
+        model_id=model_id,
+    )
+    return client.answer(system_prompt=system_prompt, user_prompt=user_prompt)
 
 
 def _format_jira(issues: list[dict[str, Any]]) -> str:
@@ -175,8 +260,42 @@ def handle_query(
     confluence_cql: str,
     correlation_id: str,
     retrieval_mode: str | None = None,
+    assistant_mode: str | None = None,
+    llm_provider: str | None = None,
+    model_id: str | None = None,
 ) -> dict[str, Any]:
     local_logger = get_logger("jira_confluence_chatbot", correlation_id=correlation_id)
+
+    resolved_assistant_mode = _normalize_assistant_mode(assistant_mode)
+    resolved_llm_provider = _normalize_llm_provider(llm_provider)
+    resolved_model_id = _resolve_model_id(resolved_llm_provider, model_id)
+
+    if resolved_assistant_mode == "general":
+        system_prompt = (
+            "You are a helpful enterprise AI assistant. Provide clear, practical answers. "
+            "If policies or environment constraints are unknown, state assumptions explicitly."
+        )
+        answer = _answer_with_provider(
+            provider=resolved_llm_provider,
+            model_id=resolved_model_id,
+            system_prompt=system_prompt,
+            user_prompt=query,
+        )
+
+        return {
+            "answer": answer,
+            "sources": {
+                "assistant_mode": resolved_assistant_mode,
+                "provider": resolved_llm_provider,
+                "model_id": resolved_model_id,
+                "mode": "none",
+                "context_source": "none",
+                "kb_count": 0,
+                "jira_count": 0,
+                "confluence_count": 0,
+                "github_count": 0,
+            },
+        }
 
     # M6: Normalize once — callers may pass None for env-var fallback
     mode = _normalize_retrieval_mode(retrieval_mode or os.getenv("CHATBOT_RETRIEVAL_MODE", "hybrid"))
@@ -229,16 +348,20 @@ def handle_query(
         f"GitHub context:\n{context_blob['github']}\n"
     )
 
-    chatbot = BedrockChatClient(
-        region=os.getenv("AWS_REGION", DEFAULT_REGION),
-        model_id=os.getenv("CHATBOT_MODEL_ID", os.environ.get("BEDROCK_MODEL_ID", "")),
+    answer = _answer_with_provider(
+        provider=resolved_llm_provider,
+        model_id=resolved_model_id,
+        system_prompt=system_prompt,
+        user_prompt=user_prompt,
     )
-    answer = chatbot.answer(system_prompt=system_prompt, user_prompt=user_prompt)
 
     local_logger.info(
         "chatbot_answered",
         extra={
             "extra": {
+                "assistant_mode": resolved_assistant_mode,
+                "provider": resolved_llm_provider,
+                "model_id": resolved_model_id,
                 "retrieval_mode": mode,
                 "context_source": context_source,
                 "jira_items": len(jira_items),
@@ -252,6 +375,9 @@ def handle_query(
     return {
         "answer": answer,
         "sources": {
+            "assistant_mode": resolved_assistant_mode,
+            "provider": resolved_llm_provider,
+            "model_id": resolved_model_id,
             "mode": mode,
             "context_source": context_source,
             "kb_count": len(kb_items),
@@ -294,17 +420,35 @@ def lambda_handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
     jira_jql = str(body.get("jira_jql") or "").strip() or "order by updated DESC"
     confluence_cql = str(body.get("confluence_cql") or "").strip() or "type=page order by lastmodified desc"
 
-    # M9: CQL/JQL input validation
-    if not _validate_query_filter(jira_jql) or not _validate_query_filter(confluence_cql):
-        return {"statusCode": 400, "body": json.dumps({"error": "invalid_query_filter"})}
-
+    assistant_mode = _normalize_assistant_mode(body.get("assistant_mode"))
+    llm_provider = _normalize_llm_provider(body.get("llm_provider"))
+    model_id = str(body.get("model_id") or "").strip() or None
     retrieval_mode = _normalize_retrieval_mode(body.get("retrieval_mode"))
+
+    # CQL/JQL validation is only required for contextual mode
+    if assistant_mode == "contextual":
+        if not _validate_query_filter(jira_jql) or not _validate_query_filter(confluence_cql):
+            return {"statusCode": 400, "body": json.dumps({"error": "invalid_query_filter"})}
 
     correlation_id = event.get("requestContext", {}).get("requestId", "unknown")
 
     # M5: Structured error handling
     try:
-        response_body = handle_query(query, jira_jql, confluence_cql, correlation_id, retrieval_mode=retrieval_mode)
+        response_body = handle_query(
+            query,
+            jira_jql,
+            confluence_cql,
+            correlation_id,
+            retrieval_mode=retrieval_mode,
+            assistant_mode=assistant_mode,
+            llm_provider=llm_provider,
+            model_id=model_id,
+        )
+    except ValueError as exc:
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"error": str(exc)}),
+        }
     except Exception:
         logger.exception("chatbot_internal_error", extra={"extra": {"correlation_id": correlation_id}})
         return {

--- a/src/shared/anthropic_chat.py
+++ b/src/shared/anthropic_chat.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+
+
+class AnthropicChatClient:
+    def __init__(
+        self,
+        api_key: str,
+        model_id: str,
+        api_base: str = "https://api.anthropic.com",
+        max_tokens: int = 1200,
+        timeout_seconds: int = 30,
+    ) -> None:
+        self._api_key = api_key.strip()
+        self._model_id = model_id.strip()
+        self._api_base = api_base.rstrip("/")
+        self._max_tokens = max_tokens
+        self._timeout_seconds = timeout_seconds
+
+    def answer(self, system_prompt: str, user_prompt: str) -> str:
+        resp = requests.post(
+            f"{self._api_base}/v1/messages",
+            headers={
+                "x-api-key": self._api_key,
+                "anthropic-version": "2023-06-01",
+                "content-type": "application/json",
+            },
+            json={
+                "model": self._model_id,
+                "max_tokens": self._max_tokens,
+                "temperature": 0.2,
+                "system": system_prompt,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": user_prompt,
+                    }
+                ],
+            },
+            timeout=self._timeout_seconds,
+        )
+        resp.raise_for_status()
+
+        payload: dict[str, Any] = resp.json()
+        content = payload.get("content", [])
+        if not content:
+            return "I could not produce a response."
+
+        first = content[0] if isinstance(content[0], dict) else {}
+        text = first.get("text")
+        if isinstance(text, str) and text.strip():
+            return text
+        return "I could not produce a response."

--- a/webapp/app.js
+++ b/webapp/app.js
@@ -3,6 +3,9 @@ const ids = {
   authMode: document.getElementById("authMode"),
   authValue: document.getElementById("authValue"),
   retrievalMode: document.getElementById("retrievalMode"),
+  assistantMode: document.getElementById("assistantMode"),
+  llmProvider: document.getElementById("llmProvider"),
+  modelId: document.getElementById("modelId"),
   query: document.getElementById("query"),
   jiraJql: document.getElementById("jiraJql"),
   confluenceCql: document.getElementById("confluenceCql"),
@@ -34,6 +37,9 @@ function loadSettings() {
     ids.authMode.value = s.authMode || "token";
     ids.authValue.value = s.authValue || "";
     ids.retrievalMode.value = s.retrievalMode || "hybrid";
+    ids.assistantMode.value = s.assistantMode || "contextual";
+    ids.llmProvider.value = s.llmProvider || "bedrock";
+    ids.modelId.value = s.modelId || "";
     ids.jiraJql.value = s.jiraJql || "";
     ids.confluenceCql.value = s.confluenceCql || "";
     ids.githubOauthBaseUrl.value = s.githubOauthBaseUrl || "";
@@ -50,6 +56,9 @@ function saveSettings() {
     authMode: ids.authMode.value,
     authValue: ids.authValue.value,
     retrievalMode: ids.retrievalMode.value,
+    assistantMode: ids.assistantMode.value,
+    llmProvider: ids.llmProvider.value,
+    modelId: ids.modelId.value.trim(),
     jiraJql: ids.jiraJql.value.trim(),
     confluenceCql: ids.confluenceCql.value.trim(),
     githubOauthBaseUrl: ids.githubOauthBaseUrl.value.trim(),
@@ -231,8 +240,13 @@ async function askChatbot() {
 
   const payload = {
     query,
+    assistant_mode: ids.assistantMode.value,
+    llm_provider: ids.llmProvider.value,
     retrieval_mode: ids.retrievalMode.value,
   };
+
+  const modelId = ids.modelId.value.trim();
+  if (modelId) payload.model_id = modelId;
 
   const jiraJql = ids.jiraJql.value.trim();
   const confluenceCql = ids.confluenceCql.value.trim();

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -38,7 +38,32 @@
               <option value="live">live</option>
             </select>
           </label>
+          <label>
+            Assistant Mode
+            <select id="assistantMode">
+              <option value="contextual">contextual (Jira/Confluence/KB aware)</option>
+              <option value="general">general AI chat</option>
+            </select>
+          </label>
+          <label>
+            LLM Provider
+            <select id="llmProvider">
+              <option value="bedrock">bedrock</option>
+              <option value="anthropic_direct">anthropic_direct (optional)</option>
+            </select>
+          </label>
+          <label>
+            Model ID (optional override)
+            <input id="modelId" list="modelSuggestions" placeholder="amazon.nova-pro-v1:0 or anthropic.claude-3-7-sonnet-v1:0" />
+          </label>
         </div>
+        <datalist id="modelSuggestions">
+          <option value="amazon.nova-lite-v1:0"></option>
+          <option value="amazon.nova-pro-v1:0"></option>
+          <option value="amazon.titan-text-premier-v1:0"></option>
+          <option value="anthropic.claude-3-7-sonnet-20250219-v1:0"></option>
+          <option value="anthropic.claude-3-5-sonnet-20241022-v2:0"></option>
+        </datalist>
         <details class="gh-login" id="ghLoginPanel">
           <summary>GitHub Login (device flow, optional)</summary>
           <p class="muted small">


### PR DESCRIPTION
## Summary
- add assistant_mode support for contextual vs general AI chat
- add provider routing between Bedrock and optional anthropic_direct
- add request-level model_id override with optional Bedrock allow-list
- switch Bedrock chat client to Converse API for broader model compatibility
- add web UI controls for assistant mode/provider/model and model suggestions
- add Terraform variables/env wiring for provider defaults and direct Anthropic config
- expand chatbot helper tests for general mode, routing, and allow-list validation

## Validation
- python -m ruff check src tests scripts
- python -m pytest -q