### PR TITLE
feat(chatbot): add GovCloud Bedrock model discovery endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ Bedrock model selection controls:
 - `CHATBOT_ALLOWED_MODEL_IDS` (CSV; optional allow-list for request `model_id`)
 - If unset, any model ID available to the account/region can be requested.
 
+Model discovery endpoint:
+
+- `GET /chatbot/models`
+- Returns active text-capable Bedrock foundation models visible in the configured region (GovCloud), optionally filtered by `CHATBOT_ALLOWED_MODEL_IDS`.
+
 Optional live GitHub lookup (disabled by default):
 
 - `chatbot_github_live_enabled=true`
@@ -253,6 +258,10 @@ In the UI, provide:
 - Assistant Mode (`contextual` or `general`)
 - LLM Provider (`bedrock` or `anthropic_direct`)
 - Optional Model ID override (for example Amazon-hosted Bedrock model IDs)
+
+To load currently active GovCloud model options into the model picker:
+
+- Click **Refresh GovCloud Models** in the web app.
 
 Optional GitHub login in web app:
 

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -467,6 +467,7 @@ resource "aws_iam_policy" "chatbot_policy" {
         Effect = "Allow"
         Action = [
           "bedrock:InvokeModel",
+          "bedrock:ListFoundationModels",
           "bedrock:Retrieve",
           "bedrock:RetrieveAndGenerate"
         ]
@@ -904,6 +905,17 @@ resource "aws_apigatewayv2_route" "chatbot" {
   count              = var.chatbot_enabled ? 1 : 0
   api_id             = aws_apigatewayv2_api.webhook.id
   route_key          = "POST /chatbot/query"
+  target             = "integrations/${aws_apigatewayv2_integration.chatbot_lambda[0].id}"
+  authorization_type = local.chatbot_route_auth_type
+  authorizer_id = local.chatbot_auth_jwt_enabled ? aws_apigatewayv2_authorizer.chatbot_jwt[0].id : (
+    local.chatbot_auth_github_oauth_enabled ? aws_apigatewayv2_authorizer.chatbot_github_oauth[0].id : null
+  )
+}
+
+resource "aws_apigatewayv2_route" "chatbot_models" {
+  count              = var.chatbot_enabled ? 1 : 0
+  api_id             = aws_apigatewayv2_api.webhook.id
+  route_key          = "GET /chatbot/models"
   target             = "integrations/${aws_apigatewayv2_integration.chatbot_lambda[0].id}"
   authorization_type = local.chatbot_route_auth_type
   authorizer_id = local.chatbot_auth_jwt_enabled ? aws_apigatewayv2_authorizer.chatbot_jwt[0].id : (

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -9,6 +9,7 @@
 - Enforce enterprise hosted GitHub OAuth endpoint usage in the chatbot web login flow.
 - Support general AI chat mode and model/provider selection in chatbot requests.
 - Allow optional direct Anthropic provider while keeping Bedrock as default.
+- Expose dynamic GovCloud Bedrock model discovery for chat model selection (`GET /chatbot/models`).
 
 ## Current Blockers
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -16,6 +16,7 @@
 - [x] Add LLM provider routing (`bedrock` and optional `anthropic_direct`)
 - [x] Add optional request `model_id` override with Bedrock allow-list support
 - [x] Add webapp controls for assistant mode/provider/model override
+- [x] Add GovCloud model discovery endpoint and webapp refresh for active Bedrock models
 - [x] Add Terraform knobs for provider defaults and Anthropic direct configuration
 - [x] Verify test suite after chat/provider/model updates (`174 passed`)
 

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -57,6 +57,9 @@
             <input id="modelId" list="modelSuggestions" placeholder="amazon.nova-pro-v1:0 or anthropic.claude-3-7-sonnet-v1:0" />
           </label>
         </div>
+        <div class="actions">
+          <button id="refreshModelsBtn" type="button">Refresh GovCloud Models</button>
+        </div>
         <datalist id="modelSuggestions">
           <option value="amazon.nova-lite-v1:0"></option>
           <option value="amazon.nova-pro-v1:0"></option>


### PR DESCRIPTION
## Summary
- add GET /chatbot/models endpoint to return active text Bedrock models in GovCloud
- filter model list by CHATBOT_ALLOWED_MODEL_IDS when configured
- add webapp Refresh GovCloud Models button to load model options dynamically
- add API Gateway route and IAM permission for Bedrock model listing
- add tests for model listing and GET handler path

## Validation
- python -m ruff check src tests scripts
- python -m pytest -q