### PR TITLE
feat(chatbot): add memory, stream, and image generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ Chatbot endpoint:
 - `POST /chatbot/query`
 - JSON body:
   - `query` (required)
+  - `conversation_id` (optional; enables per-thread memory when memory is enabled)
+  - `stream` (optional bool; returns chunked stream payload for stream-style UI)
+  - `stream_chunk_chars` (optional int; chunk size for stream payload)
   - `assistant_mode` (optional: `contextual|general`; defaults to `contextual`)
   - `llm_provider` (optional: `bedrock|anthropic_direct`; defaults to `bedrock`)
   - `model_id` (optional override; validated against allow-list when configured)
@@ -122,6 +125,22 @@ Model discovery endpoint:
 
 - `GET /chatbot/models`
 - Returns active text-capable Bedrock foundation models visible in the configured region (GovCloud), optionally filtered by `CHATBOT_ALLOWED_MODEL_IDS`.
+
+Image generation endpoint:
+
+- `POST /chatbot/image`
+- JSON body:
+  - `query` (required image prompt)
+  - `model_id` (optional Bedrock image model override)
+  - `size` (optional `WIDTHxHEIGHT`, defaults to `CHATBOT_IMAGE_SIZE`)
+- Returns base64-encoded image payload(s) in `images`.
+
+Conversation memory options (optional):
+
+- `CHATBOT_MEMORY_ENABLED=true|false`
+- `CHATBOT_MEMORY_TABLE=<dynamodb table name>`
+- `CHATBOT_MEMORY_MAX_TURNS` (default `6`)
+- `CHATBOT_MEMORY_TTL_DAYS` (default `30`)
 
 Optional live GitHub lookup (disabled by default):
 
@@ -258,10 +277,16 @@ In the UI, provide:
 - Assistant Mode (`contextual` or `general`)
 - LLM Provider (`bedrock` or `anthropic_direct`)
 - Optional Model ID override (for example Amazon-hosted Bedrock model IDs)
+- Optional Conversation ID to retain memory across messages
+- Stream-style response mode toggle
 
 To load currently active GovCloud model options into the model picker:
 
 - Click **Refresh GovCloud Models** in the web app.
+
+To generate an image from the same prompt field:
+
+- Click **Generate Image** in the web app.
 
 Optional GitHub login in web app:
 

--- a/infra/terraform/terraform.nonprod.tfvars.example
+++ b/infra/terraform/terraform.nonprod.tfvars.example
@@ -39,6 +39,11 @@ chatbot_anthropic_model_id = "claude-sonnet-4-5"
 chatbot_github_live_enabled = false
 chatbot_github_live_repos = ["my-org/my-repo"]
 chatbot_github_live_max_results = 3
+chatbot_memory_enabled = true
+chatbot_memory_max_turns = 6
+chatbot_memory_ttl_days = 30
+chatbot_image_model_id = "amazon.nova-canvas-v1:0"
+chatbot_image_default_size = "1024x1024"
 bedrock_knowledge_base_id = "<SET_KB_ID>"
 bedrock_kb_top_k        = 5
 

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -43,6 +43,11 @@ chatbot_anthropic_model_id = "claude-sonnet-4-5"
 chatbot_github_live_enabled = false
 chatbot_github_live_repos = []
 chatbot_github_live_max_results = 3
+chatbot_memory_enabled = false
+chatbot_memory_max_turns = 6
+chatbot_memory_ttl_days = 30
+chatbot_image_model_id = "amazon.nova-canvas-v1:0"
+chatbot_image_default_size = "1024x1024"
 bedrock_knowledge_base_id = ""
 bedrock_kb_top_k = 5
 

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -179,6 +179,46 @@ variable "chatbot_github_live_max_results" {
   }
 }
 
+variable "chatbot_memory_enabled" {
+  description = "Enable DynamoDB-backed chatbot conversation memory"
+  type        = bool
+  default     = false
+}
+
+variable "chatbot_memory_max_turns" {
+  description = "Maximum number of recent memory turns included in each chatbot prompt"
+  type        = number
+  default     = 6
+
+  validation {
+    condition     = var.chatbot_memory_max_turns >= 1
+    error_message = "Must be at least 1."
+  }
+}
+
+variable "chatbot_memory_ttl_days" {
+  description = "Days before stored chatbot conversation turns expire"
+  type        = number
+  default     = 30
+
+  validation {
+    condition     = var.chatbot_memory_ttl_days >= 1
+    error_message = "Must be at least 1."
+  }
+}
+
+variable "chatbot_image_model_id" {
+  description = "Bedrock image model ID for /chatbot/image endpoint"
+  type        = string
+  default     = "amazon.nova-canvas-v1:0"
+}
+
+variable "chatbot_image_default_size" {
+  description = "Default image size for /chatbot/image in WIDTHxHEIGHT format"
+  type        = string
+  default     = "1024x1024"
+}
+
 variable "bedrock_knowledge_base_id" {
   description = "Optional Bedrock Knowledge Base ID used by chatbot and sync jobs"
   type        = string

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -10,6 +10,9 @@
 - Support general AI chat mode and model/provider selection in chatbot requests.
 - Allow optional direct Anthropic provider while keeping Bedrock as default.
 - Expose dynamic GovCloud Bedrock model discovery for chat model selection (`GET /chatbot/models`).
+- Add optional conversation memory for chatbot threads.
+- Add stream-style chunked response payloads for improved UI rendering.
+- Add image generation endpoint (`POST /chatbot/image`) and webapp integration.
 
 ## Current Blockers
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -19,6 +19,11 @@
 - [x] Add GovCloud model discovery endpoint and webapp refresh for active Bedrock models
 - [x] Add Terraform knobs for provider defaults and Anthropic direct configuration
 - [x] Verify test suite after chat/provider/model updates (`174 passed`)
+- [x] Add optional chatbot conversation memory (DynamoDB-backed)
+- [x] Add stream-style response payload support and webapp progressive rendering
+- [x] Add chatbot image generation endpoint and webapp image preview
+- [x] Add Terraform wiring for chatbot memory table, IAM, and image route/env
+- [x] Add tests covering stream/memory helpers and image endpoint routing
 
 ## Doing
 

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -56,6 +56,17 @@
             Model ID (optional override)
             <input id="modelId" list="modelSuggestions" placeholder="amazon.nova-pro-v1:0 or anthropic.claude-3-7-sonnet-v1:0" />
           </label>
+          <label>
+            Conversation ID (optional)
+            <input id="conversationId" placeholder="team-standup-2026-02" />
+          </label>
+          <label>
+            Stream-style response
+            <select id="streamMode">
+              <option value="true">enabled</option>
+              <option value="false">disabled</option>
+            </select>
+          </label>
         </div>
         <div class="actions">
           <button id="refreshModelsBtn" type="button">Refresh GovCloud Models</button>
@@ -114,6 +125,7 @@
         <div class="actions">
           <button id="saveBtn" type="button">Save Settings</button>
           <button id="sendBtn" type="button">Ask Chatbot</button>
+          <button id="imageBtn" type="button">Generate Image</button>
         </div>
       </section>
 
@@ -122,6 +134,9 @@
         <div id="status" class="status muted">Ready.</div>
         <pre id="answer" class="answer">No response yet.</pre>
         <div id="sources" class="sources"></div>
+        <div id="imageWrap" class="image-wrap" hidden>
+          <img id="imagePreview" alt="Generated image preview" />
+        </div>
       </section>
     </main>
 

--- a/webapp/styles.css
+++ b/webapp/styles.css
@@ -140,3 +140,18 @@ button:hover {
   color: #cbd5e1;
   font-size: 0.9rem;
 }
+
+.image-wrap {
+  margin-top: 12px;
+  border: 1px solid #1e293b;
+  border-radius: 10px;
+  padding: 10px;
+  background: #0b1220;
+}
+
+.image-wrap img {
+  width: 100%;
+  max-height: 420px;
+  object-fit: contain;
+  border-radius: 8px;
+}


### PR DESCRIPTION
## Summary
- Add optional DynamoDB-backed chatbot conversation memory.
- Add stream-style chunked response payloads and webapp progressive rendering.
- Add image generation endpoint (/chatbot/image) and webapp preview.
- Wire Terraform (memory table, IAM, env vars, route) and update docs/tests.

## Scope
- [ ] Core PR reviewer
- [x] Chatbot / Teams
- [ ] KB sync
- [ ] Release notes
- [ ] Sprint report
- [ ] Test generation
- [ ] PR description
- [x] Terraform / IaC
- [x] Docs / runbooks
- [x] CI / quality gates

## Validation
- [x] ruff check src tests scripts
- [x] pytest -q
- [x] terraform fmt -check (if IaC changed)
- [ ] terraform validate (if IaC changed) — blocked locally by Terraform 1.5.7; repo requires >= 1.6.0