### PR TITLE
feat(chatbot): add observability metrics, alarms, and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,20 @@ Conversation memory options (optional):
 - `CHATBOT_MEMORY_MAX_TURNS` (default `6`)
 - `CHATBOT_MEMORY_TTL_DAYS` (default `30`)
 
+Chatbot observability options:
+
+- `chatbot_observability_enabled` (Terraform; default `true`)
+- `chatbot_metrics_namespace` (Terraform; optional override, defaults to `${project_name}/${environment}`)
+- Lambda emits custom metrics:
+  - `ChatbotRequestCount`
+  - `ChatbotLatencyMs`
+  - `ChatbotErrorCount`
+  - `ChatbotServerErrorCount`
+  - `ChatbotImageGeneratedCount`
+- Runtime toggle: `CHATBOT_METRICS_ENABLED=true|false`
+
+When enabled, Terraform provisions a CloudWatch dashboard for chatbot route-level telemetry and server-error alarms for query/image endpoints.
+
 Optional live GitHub lookup (disabled by default):
 
 - `chatbot_github_live_enabled=true`

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -67,3 +67,8 @@ output "pr_description_url" {
   description = "PR description generator endpoint"
   value       = var.pr_description_enabled ? "${aws_apigatewayv2_api.webhook.api_endpoint}/pr-description/generate" : ""
 }
+
+output "chatbot_observability_dashboard_name" {
+  description = "CloudWatch dashboard name for chatbot observability"
+  value       = var.chatbot_enabled && var.chatbot_observability_enabled ? aws_cloudwatch_dashboard.chatbot_observability[0].dashboard_name : ""
+}

--- a/infra/terraform/terraform.nonprod.tfvars.example
+++ b/infra/terraform/terraform.nonprod.tfvars.example
@@ -44,6 +44,8 @@ chatbot_memory_max_turns = 6
 chatbot_memory_ttl_days = 30
 chatbot_image_model_id = "amazon.nova-canvas-v1:0"
 chatbot_image_default_size = "1024x1024"
+chatbot_observability_enabled = true
+chatbot_metrics_namespace = ""
 bedrock_knowledge_base_id = "<SET_KB_ID>"
 bedrock_kb_top_k        = 5
 

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -48,6 +48,8 @@ chatbot_memory_max_turns = 6
 chatbot_memory_ttl_days = 30
 chatbot_image_model_id = "amazon.nova-canvas-v1:0"
 chatbot_image_default_size = "1024x1024"
+chatbot_observability_enabled = true
+chatbot_metrics_namespace = ""
 bedrock_knowledge_base_id = ""
 bedrock_kb_top_k = 5
 

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -219,6 +219,18 @@ variable "chatbot_image_default_size" {
   default     = "1024x1024"
 }
 
+variable "chatbot_observability_enabled" {
+  description = "Enable chatbot custom metrics dashboard and related CloudWatch alarms"
+  type        = bool
+  default     = true
+}
+
+variable "chatbot_metrics_namespace" {
+  description = "Optional CloudWatch metrics namespace override for chatbot custom metrics"
+  type        = string
+  default     = ""
+}
+
 variable "bedrock_knowledge_base_id" {
   description = "Optional Bedrock Knowledge Base ID used by chatbot and sync jobs"
   type        = string

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -14,6 +14,7 @@
 - Add stream-style chunked response payloads for improved UI rendering.
 - Add image generation endpoint (`POST /chatbot/image`) and webapp integration.
 - Execute phase-1 implementation for cross-environment toolchain consistency checks and docs.
+- Implement phase-2 chatbot observability foundation (custom metrics, alarms, dashboard).
 
 ## Current Blockers
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -27,6 +27,10 @@
 - [x] Add local toolchain pin files (`.tool-versions`, `.python-version`) for consistency
 - [x] Update Makefile with venv-aware Python and Terraform validation targets
 - [x] Make predeploy Terraform version checks derive minimum version from `versions.tf`
+- [x] Add chatbot custom CloudWatch metrics (request, latency, error, server error, image count)
+- [x] Add chatbot route-level observability alarms and CloudWatch dashboard in Terraform
+- [x] Add chatbot observability docs and output (`chatbot_observability_dashboard_name`)
+- [x] Add chatbot metric emission unit tests and keep suite green (`183 passed`)
 
 ## Doing
 


### PR DESCRIPTION
## Summary
- Add chatbot custom CloudWatch metrics by route/method/status.
- Add route-level server error alarms for query and image endpoints.
- Add CloudWatch dashboard for chatbot observability.
- Wire chatbot metrics namespace/env flags and IAM PutMetricData.
- Add tests for metric emission and update docs/outputs.

## Validation
- python -m ruff check src tests scripts
- pytest -q tests/test_chatbot_helpers.py
- pytest -q
- terraform -chdir=infra/terraform fmt -check