### PR TITLE
feat(chatbot): add websocket streaming transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ Chatbot endpoint:
   - `confluence_cql` (optional)
   - `retrieval_mode` (optional: `live|kb|hybrid`; defaults to `hybrid`)
 
+True streaming transport (WebSocket):
+
+- Connect to `chatbot_websocket_url` output (wss endpoint)
+- Send message payloads like:
+  - `{ "action": "query", "query": "...", "conversation_id": "thread-1" }`
+- Server pushes frames with `type=chunk`, then a final `type=done`
+
 Assistant mode behavior:
 
 - `contextual`: existing Jira/Confluence/KB/GitHub context-aware flow.
@@ -168,6 +175,12 @@ Chatbot observability options:
   - `ChatbotServerErrorCount`
   - `ChatbotImageGeneratedCount`
 - Runtime toggle: `CHATBOT_METRICS_ENABLED=true|false`
+
+WebSocket streaming options:
+
+- `chatbot_websocket_enabled` (Terraform; default `true`)
+- `chatbot_websocket_stage` (Terraform; default `prod`)
+- `chatbot_websocket_default_chunk_chars` (Terraform; default `120`)
 
 When enabled, Terraform provisions a CloudWatch dashboard for chatbot route-level telemetry and server-error alarms for query/image endpoints.
 

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -28,6 +28,11 @@ output "chatbot_url" {
   value       = var.chatbot_enabled ? "${aws_apigatewayv2_api.webhook.api_endpoint}/chatbot/query" : ""
 }
 
+output "chatbot_websocket_url" {
+  description = "Chatbot websocket endpoint for true streaming transport"
+  value       = var.chatbot_enabled && var.chatbot_websocket_enabled ? replace(aws_apigatewayv2_stage.chatbot_ws[0].invoke_url, "https://", "wss://") : ""
+}
+
 output "teams_chatbot_url" {
   description = "Microsoft Teams adapter endpoint"
   value       = var.chatbot_enabled && var.teams_adapter_enabled ? "${aws_apigatewayv2_api.webhook.api_endpoint}/chatbot/teams" : ""

--- a/infra/terraform/terraform.nonprod.tfvars.example
+++ b/infra/terraform/terraform.nonprod.tfvars.example
@@ -53,6 +53,9 @@ chatbot_image_user_requests_per_minute = 30
 chatbot_image_conversation_requests_per_minute = 10
 chatbot_observability_enabled = true
 chatbot_metrics_namespace = ""
+chatbot_websocket_enabled = true
+chatbot_websocket_stage = "prod"
+chatbot_websocket_default_chunk_chars = 120
 bedrock_knowledge_base_id = "<SET_KB_ID>"
 bedrock_kb_top_k        = 5
 

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -57,6 +57,9 @@ chatbot_image_user_requests_per_minute = 30
 chatbot_image_conversation_requests_per_minute = 10
 chatbot_observability_enabled = true
 chatbot_metrics_namespace = ""
+chatbot_websocket_enabled = true
+chatbot_websocket_stage = "prod"
+chatbot_websocket_default_chunk_chars = 120
 bedrock_knowledge_base_id = ""
 bedrock_kb_top_k = 5
 

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -306,6 +306,29 @@ variable "chatbot_metrics_namespace" {
   default     = ""
 }
 
+variable "chatbot_websocket_enabled" {
+  description = "Enable websocket transport for true chatbot streaming responses"
+  type        = bool
+  default     = true
+}
+
+variable "chatbot_websocket_stage" {
+  description = "API Gateway websocket stage name for chatbot streaming transport"
+  type        = string
+  default     = "prod"
+}
+
+variable "chatbot_websocket_default_chunk_chars" {
+  description = "Default websocket response chunk size in characters"
+  type        = number
+  default     = 120
+
+  validation {
+    condition     = var.chatbot_websocket_default_chunk_chars >= 20
+    error_message = "Must be at least 20."
+  }
+}
+
 variable "bedrock_knowledge_base_id" {
   description = "Optional Bedrock Knowledge Base ID used by chatbot and sync jobs"
   type        = string

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -17,6 +17,7 @@
 - Implement phase-2 chatbot observability foundation (custom metrics, alarms, dashboard).
 - Implement phase-3 chatbot memory hygiene (actor-scoped memory, quotas, compaction, clear-memory APIs).
 - Implement phase-4 image safety and per-actor/per-conversation rate controls.
+- Implement phase-5 true websocket streaming transport for chatbot responses.
 
 ## Current Blockers
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -39,6 +39,9 @@
 - [x] Add image route per-user and per-conversation per-minute quotas
 - [x] Add Terraform variables/env wiring for image safety and quotas
 - [x] Add image route tests for safety blocking and 429 quota responses
+- [x] Add websocket streaming transport handler for chatbot query chunks (`action=query`)
+- [x] Add Terraform websocket API resources, invoke permission, and output URL
+- [x] Add websocket unit tests for chunk/done frame flow and unsupported route handling
 
 ## Doing
 


### PR DESCRIPTION
## Summary
- add websocket event handling to chatbot lambda for true chunked streaming transport
- support action=query websocket messages and emit chunk and done frames
- add API Gateway websocket resources, invoke permissions, and chatbot_websocket_url output
- add Terraform knobs for websocket enablement, stage, and default chunk size
- add websocket unit tests and update README/memory-bank tracking

## Validation
- pytest -q tests/test_chatbot_helpers.py
- pytest -q
- terraform -chdir=infra/terraform fmt
- terraform -chdir=infra/terraform fmt -check
