### PR TITLE
feat(mcp): add multiple MCP server options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ BEDROCK_MODEL_ID=anthropic.claude-3-sonnet-20240229-v1:0
 # For github.com: https://api.github.com
 # For GitHub Enterprise Server: https://<your-ghes-hostname>/api/v3
 GITHUB_API_BASE=https://github.example.com/api/v3
+GITHUB_APP_IDS_SECRET_ARN=
+GITHUB_APP_PRIVATE_KEY_SECRET_ARN=
 DRY_RUN=true
 AUTO_PR_ENABLED=false
 AUTO_PR_MAX_FILES=5

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint test check terraform-fmt-check terraform-validate verify-toolchain
+.PHONY: install install-mcp mcp-github-server mcp-atlassian-server mcp-github-release-server mcp-unified-server mcp-list lint test check terraform-fmt-check terraform-validate verify-toolchain
 
 PYTHON ?= $(if $(wildcard .venv/bin/python),.venv/bin/python,python3)
 TERRAFORM ?= terraform
@@ -6,6 +6,28 @@ TERRAFORM ?= terraform
 install:
 	$(PYTHON) -m pip install -r requirements.txt
 	$(PYTHON) -m pip install ruff pytest
+
+install-mcp:
+	$(PYTHON) -m pip install -r requirements-mcp.txt
+
+mcp-github-server:
+	PYTHONPATH=src $(PYTHON) -m mcp_server.github_pr_server
+
+mcp-atlassian-server:
+	PYTHONPATH=src $(PYTHON) -m mcp_server.atlassian_context_server
+
+mcp-github-release-server:
+	PYTHONPATH=src $(PYTHON) -m mcp_server.github_release_ops_server
+
+mcp-unified-server:
+	PYTHONPATH=src $(PYTHON) -m mcp_server.unified_context_server
+
+mcp-list:
+	@echo "Available MCP servers:"
+	@echo "  - make mcp-github-server         # PR intelligence tools"
+	@echo "  - make mcp-github-release-server # tags/releases/compare tools"
+	@echo "  - make mcp-atlassian-server      # Jira/Confluence tools"
+	@echo "  - make mcp-unified-server        # GitHub + Atlassian context tools"
 
 lint:
 	$(PYTHON) -m ruff check src tests scripts

--- a/README.md
+++ b/README.md
@@ -319,6 +319,67 @@ Quick local consistency checks:
 - `python scripts/trigger_kb_sync.py --function-name <kb_sync_function_name>`
 - `python scripts/predeploy_nonprod_checks.py --tfvars infra/terraform/terraform.tfvars`
 
+### GitHub MCP server (optional)
+
+This repo now includes an MCP server that reuses existing GitHub App auth/client code:
+
+- Entry point: `src/mcp_server/github_pr_server.py`
+- Optional dependency file: `requirements-mcp.txt`
+
+Additional MCP server options are available:
+
+- `src/mcp_server/github_release_ops_server.py`
+- `src/mcp_server/atlassian_context_server.py`
+- `src/mcp_server/unified_context_server.py`
+
+Install + run:
+
+- `make install-mcp`
+- `export GITHUB_APP_IDS_SECRET_ARN=<secret-arn>`
+- `export GITHUB_APP_PRIVATE_KEY_SECRET_ARN=<secret-arn>`
+- `export GITHUB_API_BASE=https://api.github.com` (or your GHES API base)
+- `make mcp-github-server`
+
+Atlassian MCP env var:
+
+- `export ATLASSIAN_CREDENTIALS_SECRET_ARN=<secret-arn>`
+
+List/run server options:
+
+- `make mcp-list`
+- `make mcp-github-server`
+- `make mcp-github-release-server`
+- `make mcp-atlassian-server`
+- `make mcp-unified-server`
+
+Exposed MCP tools:
+
+- `list_open_pull_requests(repo_full_name, per_page=20)`
+- `get_pull_request(repo_full_name, pull_number)`
+- `get_pull_request_files(repo_full_name, pull_number)`
+- `search_repository_code(repo_full_name, query, per_page=10)`
+
+Other server toolsets:
+
+- GitHub Release/Ops:
+  - `list_tags(repo_full_name, per_page=30)`
+  - `get_latest_release(repo_full_name)`
+  - `get_release_by_tag(repo_full_name, tag)`
+  - `compare_commits(repo_full_name, base, head)`
+  - `list_merged_prs_between(repo_full_name, base_sha, head_sha)`
+- Atlassian Context:
+  - `get_jira_issue(issue_key)`
+  - `search_jira(jql, max_results=10)`
+  - `get_confluence_page(page_id, body_format="storage")`
+  - `search_confluence(cql, limit=10)`
+  - `get_atlassian_platform()`
+- Unified Context:
+  - `github_list_open_pull_requests(...)`
+  - `github_search_repository_code(...)`
+  - `jira_search(...)`
+  - `confluence_search(...)`
+  - `health_context()`
+
 ### Small local web app (chatbot UI)
 
 This repository now includes a tiny browser UI for querying the chatbot API:

--- a/requirements-mcp.txt
+++ b/requirements-mcp.txt
@@ -1,0 +1,3 @@
+# Optional dependencies for running MCP servers in this repository.
+# Keep separate from Lambda requirements to avoid bloating deployment bundles.
+mcp>=1.0.0,<2.0.0

--- a/src/mcp_server/__init__.py
+++ b/src/mcp_server/__init__.py
@@ -1,0 +1,1 @@
+"""MCP server modules for AI PR Reviewer."""

--- a/src/mcp_server/atlassian_context_server.py
+++ b/src/mcp_server/atlassian_context_server.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from mcp_server.common import atlassian_client
+
+mcp = FastMCP("atlassian-context")
+
+
+@mcp.tool()
+def get_jira_issue(issue_key: str) -> dict[str, Any]:
+    """Fetch Jira issue details by key (example: PROJ-123)."""
+    key = (issue_key or "").strip().upper()
+    if not key:
+        raise ValueError("issue_key must not be empty")
+    return atlassian_client().get_jira_issue(key)
+
+
+@mcp.tool()
+def search_jira(jql: str, max_results: int = 10) -> list[dict[str, Any]]:
+    """Search Jira issues with JQL."""
+    query = (jql or "").strip()
+    if not query:
+        raise ValueError("jql must not be empty")
+    limit = max(1, min(int(max_results), 50))
+    return atlassian_client().search_jira(query, max_results=limit)
+
+
+@mcp.tool()
+def get_confluence_page(page_id: str, body_format: str = "storage") -> dict[str, Any]:
+    """Fetch Confluence page details by page ID."""
+    pid = (page_id or "").strip()
+    if not pid:
+        raise ValueError("page_id must not be empty")
+    fmt = (body_format or "storage").strip() or "storage"
+    return atlassian_client().get_confluence_page(pid, body_format=fmt)
+
+
+@mcp.tool()
+def search_confluence(cql: str, limit: int = 10) -> list[dict[str, Any]]:
+    """Search Confluence content using CQL."""
+    query = (cql or "").strip()
+    if not query:
+        raise ValueError("cql must not be empty")
+    page_limit = max(1, min(int(limit), 50))
+    return atlassian_client().search_confluence(query, limit=page_limit)
+
+
+@mcp.tool()
+def get_atlassian_platform() -> dict[str, str]:
+    """Return configured Atlassian platform (cloud or datacenter)."""
+    client = atlassian_client()
+    return {"platform": client.platform}
+
+
+def main() -> None:
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mcp_server/common.py
+++ b/src/mcp_server/common.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+
+from shared.atlassian_client import AtlassianClient
+from shared.github_app_auth import GitHubAppAuth
+from shared.github_client import GitHubClient
+
+
+def required_env(name: str) -> str:
+    value = os.getenv(name, "").strip()
+    if not value:
+        raise RuntimeError(f"Missing required environment variable: {name}")
+    return value
+
+
+def parse_repo(repo_full_name: str) -> tuple[str, str]:
+    value = (repo_full_name or "").strip()
+    if "/" not in value:
+        raise ValueError("repo_full_name must be in the form 'owner/repo'")
+    owner, repo = value.split("/", 1)
+    owner = owner.strip()
+    repo = repo.strip()
+    if not owner or not repo:
+        raise ValueError("repo_full_name must be in the form 'owner/repo'")
+    return owner, repo
+
+
+@lru_cache(maxsize=1)
+def github_client() -> GitHubClient:
+    app_ids_secret_arn = required_env("GITHUB_APP_IDS_SECRET_ARN")
+    private_key_secret_arn = required_env("GITHUB_APP_PRIVATE_KEY_SECRET_ARN")
+    api_base = os.getenv("GITHUB_API_BASE", "https://api.github.com")
+
+    auth = GitHubAppAuth(
+        app_ids_secret_arn=app_ids_secret_arn,
+        private_key_secret_arn=private_key_secret_arn,
+        api_base=api_base,
+    )
+    return GitHubClient(token_provider=auth.get_installation_token, api_base=api_base)
+
+
+@lru_cache(maxsize=1)
+def atlassian_client() -> AtlassianClient:
+    credentials_secret_arn = required_env("ATLASSIAN_CREDENTIALS_SECRET_ARN")
+    return AtlassianClient(credentials_secret_arn=credentials_secret_arn)

--- a/src/mcp_server/github_pr_server.py
+++ b/src/mcp_server/github_pr_server.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from mcp_server.common import github_client, parse_repo
+
+mcp = FastMCP("github-pr-intelligence")
+
+
+@mcp.tool()
+def list_open_pull_requests(repo_full_name: str, per_page: int = 20) -> list[dict[str, Any]]:
+    """List open pull requests for a repository."""
+    owner, repo = parse_repo(repo_full_name)
+    per_page = max(1, min(int(per_page), 100))
+    pulls = github_client().list_pulls(owner=owner, repo=repo, state="open", per_page=per_page)
+    return [
+        {
+            "number": pr.get("number"),
+            "title": pr.get("title"),
+            "state": pr.get("state"),
+            "author": (pr.get("user") or {}).get("login"),
+            "updated_at": pr.get("updated_at"),
+            "html_url": pr.get("html_url"),
+        }
+        for pr in pulls
+    ]
+
+
+@mcp.tool()
+def get_pull_request(repo_full_name: str, pull_number: int) -> dict[str, Any]:
+    """Get full pull request details for one PR."""
+    owner, repo = parse_repo(repo_full_name)
+    pr = github_client().get_pull_request(owner, repo, int(pull_number))
+    return {
+        "number": pr.get("number"),
+        "title": pr.get("title"),
+        "state": pr.get("state"),
+        "body": pr.get("body"),
+        "author": (pr.get("user") or {}).get("login"),
+        "base_ref": ((pr.get("base") or {}).get("ref")),
+        "head_ref": ((pr.get("head") or {}).get("ref")),
+        "mergeable": pr.get("mergeable"),
+        "draft": pr.get("draft"),
+        "updated_at": pr.get("updated_at"),
+        "html_url": pr.get("html_url"),
+    }
+
+
+@mcp.tool()
+def get_pull_request_files(repo_full_name: str, pull_number: int) -> list[dict[str, Any]]:
+    """List changed files for a pull request with patch metadata."""
+    owner, repo = parse_repo(repo_full_name)
+    files = github_client().get_pull_request_files(owner, repo, int(pull_number))
+    return [
+        {
+            "filename": f.get("filename"),
+            "status": f.get("status"),
+            "additions": f.get("additions"),
+            "deletions": f.get("deletions"),
+            "changes": f.get("changes"),
+            "patch": f.get("patch"),
+        }
+        for f in files
+    ]
+
+
+@mcp.tool()
+def search_repository_code(repo_full_name: str, query: str, per_page: int = 10) -> list[dict[str, Any]]:
+    """Search code within a specific repository."""
+    owner, repo = parse_repo(repo_full_name)
+    q = (query or "").strip()
+    if not q:
+        raise ValueError("query must not be empty")
+
+    per_page = max(1, min(int(per_page), 50))
+    scoped_query = f"{q} repo:{owner}/{repo}"
+    results = github_client().search_code(scoped_query, per_page=per_page)
+    return [
+        {
+            "name": item.get("name"),
+            "path": item.get("path"),
+            "sha": item.get("sha"),
+            "url": item.get("html_url"),
+            "repository": ((item.get("repository") or {}).get("full_name")),
+        }
+        for item in results
+    ]
+
+
+def main() -> None:
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mcp_server/github_release_ops_server.py
+++ b/src/mcp_server/github_release_ops_server.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from mcp_server.common import github_client, parse_repo
+
+mcp = FastMCP("github-release-ops")
+
+
+@mcp.tool()
+def list_tags(repo_full_name: str, per_page: int = 30) -> list[dict[str, Any]]:
+    """List repository tags (newest first)."""
+    owner, repo = parse_repo(repo_full_name)
+    page_size = max(1, min(int(per_page), 100))
+    return github_client().list_tags(owner, repo, per_page=page_size)
+
+
+@mcp.tool()
+def get_latest_release(repo_full_name: str) -> dict[str, Any]:
+    """Get latest release metadata for a repository."""
+    owner, repo = parse_repo(repo_full_name)
+    return github_client().get_latest_release(owner, repo)
+
+
+@mcp.tool()
+def get_release_by_tag(repo_full_name: str, tag: str) -> dict[str, Any]:
+    """Get release by tag name."""
+    owner, repo = parse_repo(repo_full_name)
+    tag_name = (tag or "").strip()
+    if not tag_name:
+        raise ValueError("tag must not be empty")
+    return github_client().get_release_by_tag(owner, repo, tag_name)
+
+
+@mcp.tool()
+def compare_commits(repo_full_name: str, base: str, head: str) -> dict[str, Any]:
+    """Compare commits/tags/branches and return changed files + commits."""
+    owner, repo = parse_repo(repo_full_name)
+    base_ref = (base or "").strip()
+    head_ref = (head or "").strip()
+    if not base_ref or not head_ref:
+        raise ValueError("both base and head are required")
+    return github_client().compare_commits(owner, repo, base_ref, head_ref)
+
+
+@mcp.tool()
+def list_merged_prs_between(repo_full_name: str, base_sha: str, head_sha: str) -> list[dict[str, Any]]:
+    """Return merged PRs whose merge commits are between base and head."""
+    owner, repo = parse_repo(repo_full_name)
+    base_value = (base_sha or "").strip()
+    head_value = (head_sha or "").strip()
+    if not base_value or not head_value:
+        raise ValueError("both base_sha and head_sha are required")
+    return github_client().list_merged_pulls_between(owner, repo, base_value, head_value)
+
+
+def main() -> None:
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mcp_server/unified_context_server.py
+++ b/src/mcp_server/unified_context_server.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from mcp_server.common import atlassian_client, github_client, parse_repo
+
+mcp = FastMCP("org-unified-context")
+
+
+@mcp.tool()
+def github_list_open_pull_requests(repo_full_name: str, per_page: int = 20) -> list[dict[str, Any]]:
+    """List open GitHub pull requests for a repository."""
+    owner, repo = parse_repo(repo_full_name)
+    page_size = max(1, min(int(per_page), 100))
+    pulls = github_client().list_pulls(owner=owner, repo=repo, state="open", per_page=page_size)
+    return [
+        {
+            "number": pr.get("number"),
+            "title": pr.get("title"),
+            "state": pr.get("state"),
+            "author": (pr.get("user") or {}).get("login"),
+            "updated_at": pr.get("updated_at"),
+            "html_url": pr.get("html_url"),
+        }
+        for pr in pulls
+    ]
+
+
+@mcp.tool()
+def github_search_repository_code(repo_full_name: str, query: str, per_page: int = 10) -> list[dict[str, Any]]:
+    """Search code in a GitHub repository."""
+    owner, repo = parse_repo(repo_full_name)
+    q = (query or "").strip()
+    if not q:
+        raise ValueError("query must not be empty")
+    page_size = max(1, min(int(per_page), 50))
+    scoped = f"{q} repo:{owner}/{repo}"
+    return github_client().search_code(scoped, per_page=page_size)
+
+
+@mcp.tool()
+def jira_search(jql: str, max_results: int = 10) -> list[dict[str, Any]]:
+    """Search Jira issues with JQL."""
+    query = (jql or "").strip()
+    if not query:
+        raise ValueError("jql must not be empty")
+    limit = max(1, min(int(max_results), 50))
+    return atlassian_client().search_jira(query, max_results=limit)
+
+
+@mcp.tool()
+def confluence_search(cql: str, limit: int = 10) -> list[dict[str, Any]]:
+    """Search Confluence pages/content with CQL."""
+    query = (cql or "").strip()
+    if not query:
+        raise ValueError("cql must not be empty")
+    page_limit = max(1, min(int(limit), 50))
+    return atlassian_client().search_confluence(query, limit=page_limit)
+
+
+@mcp.tool()
+def health_context() -> dict[str, str]:
+    """Return quick health/context metadata for configured providers."""
+    return {
+        "github_api_base": "configured",
+        "atlassian_platform": atlassian_client().platform,
+    }
+
+
+def main() -> None:
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary\n- add MCP server options for GitHub PR, GitHub Release/Ops, Atlassian context, and unified context\n- add shared MCP helper module for auth/client wiring\n- add optional MCP dependency file and Makefile run targets\n- document MCP setup and server matrix in README\n\n## Validation\n- make check\n- MCP import smoke test for all server modules\n\n## Notes\n- MCP dependencies remain optional via requirements-mcp.txt\n- no Lambda packaging behavior changed