### PR TITLE
feat(network-test-scripts): add EC2-to-EC2 and EC2-to-Podman connectivity test suite

### DIFF
--- a/network-test-scripts/README.md
+++ b/network-test-scripts/README.md
@@ -1,0 +1,219 @@
+# Network Test Scripts — EC2 ↔ EC2 and EC2 ↔ Podman Container
+
+Scripts for testing and debugging TCP connectivity between:
+
+- **Two plain EC2 instances** (multi-port testing)
+- **An EC2 (RHEL8) and a Podman container on another EC2 (RHEL9)**
+
+Designed to diagnose the specific symptom where `tcpdump` sees traffic arriving
+but `nc` still reports a timeout — which almost always means a firewall, SELinux,
+or Podman networking configuration issue rather than a routing problem.
+
+---
+
+## Folder Structure
+
+```
+network-test-scripts/
+├── ec2-to-ec2/
+│   ├── server.sh              # nc listener on the receiver EC2
+│   ├── client.sh              # nc connect from the sender EC2
+│   └── multi_port_test.sh     # scan multiple ports at once
+│
+├── ec2-to-podman/
+│   ├── podman_server_setup.sh # launch an nc listener container on RHEL9
+│   ├── client_test.sh         # connect from RHEL8 to the Podman container
+│   └── check_podman_config.sh # inspect Podman networking config
+│
+├── diagnostics/
+│   ├── full_diagnostic.sh     # run everything and save a report
+│   ├── tcpdump_capture.sh     # capture + interpret traffic on a port
+│   ├── check_firewall.sh      # inspect firewalld / iptables / nftables
+│   ├── check_selinux.sh       # check SELinux status and denials
+│   └── check_iptables.sh      # show Podman iptables/nftables chains
+│
+└── fixes/
+    ├── fix_podman_firewall.sh     # fix firewalld, masquerade, Netavark
+    ├── fix_selinux_podman.sh      # fix SELinux booleans and port labels
+    └── restart_podman_network.sh  # clean restart of container + networking
+```
+
+---
+
+## Quick Start
+
+### Make scripts executable (run once)
+
+```bash
+chmod +x network-test-scripts/**/*.sh
+```
+
+---
+
+## Scenario A: EC2 to EC2 Testing
+
+**On the receiver EC2 (RHEL8):**
+```bash
+./ec2-to-ec2/server.sh 9000
+```
+
+**On the sender EC2:**
+```bash
+./ec2-to-ec2/client.sh <RECEIVER_IP> 9000
+```
+
+**Test multiple ports at once:**
+```bash
+./ec2-to-ec2/multi_port_test.sh <RECEIVER_IP> 8080,9000,9090,5000
+```
+
+---
+
+## Scenario B: EC2 (RHEL8) → Podman Container on RHEL9
+
+### 1. Start the test container on RHEL9
+
+```bash
+./ec2-to-podman/podman_server_setup.sh 9000
+```
+
+This launches an `nc` listener container with `-p 0.0.0.0:9000:9000` so it
+binds to all interfaces on the RHEL9 host (critical — `127.0.0.1` binding is
+a common failure cause).
+
+### 2. Verify Podman config on RHEL9
+
+```bash
+./ec2-to-podman/check_podman_config.sh nc-test-server
+```
+
+### 3. Test from RHEL8
+
+```bash
+./ec2-to-podman/client_test.sh <RHEL9_IP> 9000
+```
+
+---
+
+## Diagnosing the "tcpdump sees traffic but nc times out" Problem
+
+This symptom means packets reach the NIC but are dropped **before** the
+application receives them. The capture point is:
+
+```
+[Remote sender] → [NIC] → [tcpdump captures here] → [iptables/nftables] → [application]
+                                                              ↑
+                                                     DROP happens here
+```
+
+### Step 1 — Capture on both hosts simultaneously
+
+**On RHEL9 (Podman host) — watch what leaves:**
+```bash
+./diagnostics/tcpdump_capture.sh 9000
+```
+
+**On RHEL8 (receiver) — watch what arrives:**
+```bash
+./diagnostics/tcpdump_capture.sh 9000
+```
+
+Then trigger the nc test from RHEL8 in a third terminal.
+
+### Step 2 — Full diagnostic report
+
+Run on **both** hosts and compare:
+```bash
+./diagnostics/full_diagnostic.sh <OTHER_HOST_IP> 9000
+```
+Output is saved to `/tmp/network_diag_<hostname>_<timestamp>.log`.
+
+### Step 3 — Check firewall
+
+```bash
+./diagnostics/check_firewall.sh 9000     # run on RHEL9
+./diagnostics/check_firewall.sh 9000     # run on RHEL8
+```
+
+### Step 4 — Check SELinux
+
+```bash
+./diagnostics/check_selinux.sh 9000      # run on RHEL9 (Podman host)
+```
+
+### Step 5 — Check iptables/nftables Podman chains
+
+```bash
+./diagnostics/check_iptables.sh 9000     # run on RHEL9
+```
+
+---
+
+## Applying Fixes
+
+### Fix 1: firewalld + masquerade + Netavark (most common cause)
+
+```bash
+# On RHEL9 as root:
+./fixes/fix_podman_firewall.sh 9000
+```
+
+This applies:
+- `firewall-cmd --zone=public --add-port=9000/tcp --permanent`
+- `firewall-cmd --zone=public --add-masquerade --permanent`
+- Adds Podman subnet `10.88.0.0/16` to the trusted zone
+- Enables `net.ipv4.ip_forward`
+
+### Fix 2: SELinux denials
+
+```bash
+# Dry-run (diagnose only):
+./fixes/fix_selinux_podman.sh 9000 diagnose
+
+# Apply fixes:
+./fixes/fix_selinux_podman.sh 9000 fix
+```
+
+### Fix 3: Clean restart of Podman + networking
+
+```bash
+./fixes/restart_podman_network.sh nc-test-server 9000
+```
+
+---
+
+## Root Causes Addressed
+
+| Symptom | Root Cause | Fix Script |
+|---------|-----------|------------|
+| tcpdump sees SYN but no SYN-ACK | firewalld blocking port | `fix_podman_firewall.sh` |
+| No packets seen at all on receiver | Podman container traffic not leaving RHEL9 | `fix_podman_firewall.sh` (masquerade) |
+| Packets arrive, nc still times out | SELinux denying bind/accept | `fix_selinux_podman.sh` |
+| Works as root but not as user | Rootless Podman slirp4netns limitation | Use `--network=host` or run as root |
+| Intermittent timeouts | Netavark/firewalld nftables conflict | `fix_podman_firewall.sh` (trusted zone) |
+| Port published to 127.0.0.1 only | Missing `0.0.0.0` in `-p` flag | `podman_server_setup.sh` (re-run) |
+
+---
+
+## AWS Security Group Requirements
+
+Ensure the following inbound rules exist on each EC2's Security Group:
+
+| EC2 | Direction | Port | Source |
+|-----|-----------|------|--------|
+| RHEL9 (Podman host) | Inbound | your test port (e.g. 9000) | RHEL8 private IP or SG |
+| RHEL8 | Inbound | your test port | RHEL9 private IP or SG |
+
+Security Group rules are checked **before** traffic reaches the instance, so
+`tcpdump` will NOT see packets blocked by a Security Group (unlike firewalld).
+
+---
+
+## Podman Networking Notes (RHEL9)
+
+- Podman 4+ on RHEL9 uses **Netavark** (replaces CNI plugins) with an **nftables** backend
+- firewalld on RHEL9 also uses **nftables** — they can conflict
+- Rootless Podman uses **slirp4netns** or **pasta** for networking, which means:
+  - Published ports are proxied through userspace, not the kernel
+  - Ports may NOT appear in `ss -tlnp` output even when working
+  - Run containers as root (`sudo podman`) or with `--network=host` for simpler debugging

--- a/network-test-scripts/diagnostics/check_firewall.sh
+++ b/network-test-scripts/diagnostics/check_firewall.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# check_firewall.sh - Inspect firewalld, iptables, and nftables rules for a
+# specific port. Shows exactly which rules would block or allow traffic.
+# Run on EITHER host.
+#
+# Usage: ./check_firewall.sh [PORT] [PROTOCOL]
+#   PORT      Port to check (default: 9000)
+#   PROTOCOL  tcp or udp (default: tcp)
+
+set -uo pipefail
+
+PORT="${1:-9000}"
+PROTO="${2:-tcp}"
+
+echo "============================================="
+echo " FIREWALL RULE CHECK FOR PORT ${PORT}/${PROTO}"
+echo "============================================="
+echo " Host : $(hostname) / $(hostname -I | awk '{print $1}')"
+echo " OS   : $(grep PRETTY_NAME /etc/os-release | cut -d= -f2 | tr -d '\"')"
+echo "============================================="
+echo ""
+
+# ---------- firewalld ----------
+echo "── firewalld ───────────────────────────────"
+if systemctl is-active --quiet firewalld 2>/dev/null; then
+    echo "  Status  : ACTIVE"
+    echo "  Backend : $(firewall-cmd --info-service=firewalld 2>/dev/null | grep 'backend' || firewall-cmd --state)"
+
+    DEFAULT_ZONE=$(firewall-cmd --get-default-zone 2>/dev/null)
+    echo "  Default zone: ${DEFAULT_ZONE}"
+    echo ""
+    echo "  Active zones:"
+    firewall-cmd --get-active-zones 2>/dev/null | sed 's/^/    /'
+
+    echo ""
+    echo "  Port ${PORT}/${PROTO} in zone '${DEFAULT_ZONE}':"
+    if firewall-cmd --zone="${DEFAULT_ZONE}" --query-port="${PORT}/${PROTO}" 2>/dev/null; then
+        echo "    [OK ] Port ${PORT}/${PROTO} is ALLOWED in firewalld"
+    else
+        echo "    [BLOCKED] Port ${PORT}/${PROTO} is NOT allowed in firewalld"
+        echo "    Fix: firewall-cmd --zone=${DEFAULT_ZONE} --add-port=${PORT}/${PROTO} --permanent"
+        echo "         firewall-cmd --reload"
+    fi
+
+    echo ""
+    echo "  Masquerade in zone '${DEFAULT_ZONE}':"
+    if firewall-cmd --zone="${DEFAULT_ZONE}" --query-masquerade 2>/dev/null; then
+        echo "    [OK ] Masquerade is ENABLED (required for Podman -> external)"
+    else
+        echo "    [WARN] Masquerade is DISABLED"
+        echo "    Fix (needed for Podman outbound): firewall-cmd --zone=${DEFAULT_ZONE} --add-masquerade --permanent && firewall-cmd --reload"
+    fi
+
+    echo ""
+    echo "  Full zone listing for '${DEFAULT_ZONE}':"
+    firewall-cmd --zone="${DEFAULT_ZONE}" --list-all 2>/dev/null | sed 's/^/    /'
+
+    # Check all zones for the port
+    echo ""
+    echo "  Checking port ${PORT} across ALL zones:"
+    for zone in $(firewall-cmd --get-zones 2>/dev/null); do
+        if firewall-cmd --zone="${zone}" --query-port="${PORT}/${PROTO}" 2>/dev/null; then
+            echo "    Zone '${zone}': ALLOWED"
+        fi
+    done
+
+else
+    echo "  Status: INACTIVE (firewalld not running)"
+fi
+
+echo ""
+
+# ---------- iptables ----------
+echo "── iptables ────────────────────────────────"
+if command -v iptables &>/dev/null; then
+    echo "  iptables version: $(iptables --version 2>/dev/null)"
+    echo ""
+    echo "  Rules matching port ${PORT} (INPUT chain):"
+    iptables -L INPUT -n -v --line-numbers 2>/dev/null | \
+        grep -E "port ${PORT}|dpt:${PORT}|spt:${PORT}|ACCEPT|DROP|REJECT|RETURN|policy" | \
+        head -30 | sed 's/^/    /' || echo "    (no matching rules or iptables unavailable)"
+
+    echo ""
+    echo "  Rules matching port ${PORT} (FORWARD chain):"
+    iptables -L FORWARD -n -v --line-numbers 2>/dev/null | \
+        grep -E "port ${PORT}|dpt:${PORT}|ACCEPT|DROP|REJECT|RETURN|policy" | \
+        head -30 | sed 's/^/    /' || echo "    (no matching rules)"
+
+    echo ""
+    echo "  NAT rules (PREROUTING — port forwarding/DNAT):"
+    iptables -t nat -L PREROUTING -n -v --line-numbers 2>/dev/null | \
+        grep -E "port ${PORT}|dpt:${PORT}|DNAT|MASQUERADE" | \
+        head -20 | sed 's/^/    /' || echo "    (no DNAT rules)"
+
+    echo ""
+    echo "  NAT rules (POSTROUTING — masquerade):"
+    iptables -t nat -L POSTROUTING -n -v --line-numbers 2>/dev/null | \
+        grep -E "MASQUERADE|SNAT" | head -20 | sed 's/^/    /' || \
+        echo "    (no masquerade/SNAT rules)"
+
+    # Check Podman-specific chains
+    echo ""
+    echo "  Podman-specific iptables chains:"
+    iptables -L -n 2>/dev/null | grep -E "Chain PODMAN|CNI" | sed 's/^/    /' || \
+        echo "    (no Podman chains found)"
+else
+    echo "  iptables not available"
+fi
+
+echo ""
+
+# ---------- nftables ----------
+echo "── nftables ────────────────────────────────"
+if command -v nft &>/dev/null; then
+    echo "  nftables ruleset (rules mentioning port ${PORT}):"
+    nft list ruleset 2>/dev/null | grep -E -A2 -B2 "${PORT}|podman|cni|FORWARD|INPUT" | \
+        head -60 | sed 's/^/    /' || echo "    (no nftables rules or access denied)"
+else
+    echo "  nft not available"
+fi
+
+echo ""
+
+# ---------- Summary ----------
+echo "============================================="
+echo " SUMMARY FOR PORT ${PORT}/${PROTO}"
+echo "============================================="
+
+BLOCKED=false
+
+# firewalld check
+if systemctl is-active --quiet firewalld 2>/dev/null; then
+    DEFAULT_ZONE=$(firewall-cmd --get-default-zone 2>/dev/null)
+    if ! firewall-cmd --zone="${DEFAULT_ZONE}" --query-port="${PORT}/${PROTO}" 2>/dev/null; then
+        echo " [!] firewalld is BLOCKING port ${PORT} in zone '${DEFAULT_ZONE}'"
+        BLOCKED=true
+    fi
+fi
+
+if [[ "${BLOCKED}" == "false" ]]; then
+    echo " [OK] No obvious firewall blocks detected for port ${PORT}"
+    echo " If nc still fails, check:"
+    echo "   1. AWS Security Group inbound rules"
+    echo "   2. SELinux: run diagnostics/check_selinux.sh"
+    echo "   3. nc binding to wrong interface: run diagnostics/check_iptables.sh"
+fi
+echo "============================================="

--- a/network-test-scripts/diagnostics/check_iptables.sh
+++ b/network-test-scripts/diagnostics/check_iptables.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# check_iptables.sh - Show full iptables/nftables ruleset with focus on
+# Podman-created chains and any rules that could drop/reject traffic.
+# Run on the RHEL9 host running Podman.
+#
+# Usage: ./check_iptables.sh [PORT]
+
+set -uo pipefail
+
+PORT="${1:-9000}"
+
+echo "============================================="
+echo " IPTABLES / NFTABLES DEEP INSPECTION"
+echo "============================================="
+echo " Host : $(hostname)"
+echo " Port : ${PORT}"
+echo "============================================="
+echo ""
+
+# ---------- iptables full dump ----------
+echo "── iptables -L (filter table) ──────────────"
+if command -v iptables &>/dev/null; then
+    iptables -L -n -v --line-numbers 2>/dev/null | sed 's/^/  /' | head -100
+else
+    echo "  iptables not available"
+fi
+
+echo ""
+echo "── iptables NAT table ──────────────────────"
+iptables -t nat -L -n -v --line-numbers 2>/dev/null | sed 's/^/  /' | head -80 || echo "  (unavailable)"
+
+echo ""
+echo "── iptables MANGLE table ───────────────────"
+iptables -t mangle -L -n -v --line-numbers 2>/dev/null | sed 's/^/  /' | head -40 || echo "  (unavailable)"
+
+echo ""
+
+# ---------- Podman-specific chains ----------
+echo "── Podman / CNI iptables chains ────────────"
+PODMAN_CHAINS=$(iptables -L -n 2>/dev/null | grep -E '^Chain (PODMAN|CNI|NETAVARK)' || true)
+if [[ -n "${PODMAN_CHAINS}" ]]; then
+    echo "  Found Podman chains:"
+    echo "${PODMAN_CHAINS}" | sed 's/^/  /'
+    echo ""
+    # Dump each Podman chain
+    while IFS= read -r line; do
+        CHAIN=$(echo "${line}" | awk '{print $2}')
+        echo "  --- Chain: ${CHAIN} ---"
+        iptables -L "${CHAIN}" -n -v 2>/dev/null | sed 's/^/    /' || true
+    done <<< "${PODMAN_CHAINS}"
+else
+    echo "  No Podman/CNI chains found in iptables."
+    echo "  (RHEL9 with Podman 4+ uses Netavark + nftables instead)"
+fi
+
+echo ""
+
+# ---------- nftables ----------
+echo "── nftables full ruleset ───────────────────"
+if command -v nft &>/dev/null; then
+    nft list ruleset 2>/dev/null | sed 's/^/  /' || echo "  (nftables empty or access denied)"
+    echo ""
+    echo "── nftables: rules matching port ${PORT} ──"
+    nft list ruleset 2>/dev/null | grep -E -B3 -A3 "${PORT}" | sed 's/^/  /' || \
+        echo "  (no rules mentioning port ${PORT})"
+else
+    echo "  nft command not available."
+fi
+
+echo ""
+
+# ---------- FORWARD policy ----------
+echo "── FORWARD chain policy ────────────────────"
+FWD_POLICY=$(iptables -L FORWARD -n 2>/dev/null | head -1)
+echo "  ${FWD_POLICY}"
+if echo "${FWD_POLICY}" | grep -q "DROP"; then
+    echo "  [WARN] FORWARD policy is DROP — this can block container traffic."
+    echo "  Fix:   iptables -P FORWARD ACCEPT"
+    echo "         (Podman usually adds ACCEPT rules, but check above chains)"
+elif echo "${FWD_POLICY}" | grep -q "ACCEPT"; then
+    echo "  [OK ] FORWARD policy is ACCEPT."
+fi
+
+echo ""
+
+# ---------- RHEL9 Netavark check ----------
+echo "── Netavark (RHEL9 Podman 4+ network backend) ──"
+if command -v netavark &>/dev/null; then
+    echo "  netavark found: $(which netavark)"
+    # Netavark uses nftables under the hood
+    echo "  Check nftables ruleset above for Netavark rules."
+else
+    echo "  netavark not in PATH (may be bundled with Podman)"
+fi
+
+# Check for Netavark state files
+NETAVARK_STATE_DIRS=(
+    "/run/netavark"
+    "${HOME}/.local/share/containers/storage/networks"
+    "/var/lib/containers/storage/networks"
+)
+for dir in "${NETAVARK_STATE_DIRS[@]}"; do
+    if [[ -d "${dir}" ]]; then
+        echo "  Netavark state dir: ${dir}"
+        ls -la "${dir}" 2>/dev/null | sed 's/^/    /'
+    fi
+done
+
+echo ""
+
+# ---------- RHEL9 specific: check nftables backend for firewalld ----------
+echo "── firewalld nftables backend ───────────────"
+if command -v firewall-cmd &>/dev/null && systemctl is-active --quiet firewalld 2>/dev/null; then
+    FW_BACKEND=$(firewall-cmd --info-service=firewalld 2>/dev/null | grep -i backend || \
+                 grep -r 'FirewallBackend' /etc/firewalld/ 2>/dev/null | head -1 || \
+                 echo "iptables (default for RHEL8) or nftables (RHEL9)")
+    echo "  ${FW_BACKEND}"
+    echo ""
+    echo "  [INFO] On RHEL9, firewalld uses nftables backend by default."
+    echo "         Podman (Netavark) also uses nftables."
+    echo "         Conflicts between the two can drop container traffic."
+    echo "  Fix:   See fixes/fix_podman_firewall.sh for the correct approach."
+fi
+
+echo ""
+echo "============================================="
+echo " Done."
+echo "============================================="

--- a/network-test-scripts/diagnostics/check_selinux.sh
+++ b/network-test-scripts/diagnostics/check_selinux.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# check_selinux.sh - Check SELinux status and recent denials related to
+# network connections and Podman containers.
+# Run on the RHEL8 or RHEL9 host.
+#
+# Usage: ./check_selinux.sh [PORT]
+#   PORT  Specific port to check labeling for (optional, default: 9000)
+
+set -uo pipefail
+
+PORT="${1:-9000}"
+
+echo "============================================="
+echo " SELINUX NETWORK & PODMAN CHECK"
+echo "============================================="
+echo " Host : $(hostname)"
+echo " Port : ${PORT}"
+echo "============================================="
+echo ""
+
+# ---------- SELinux mode ----------
+echo "── SELinux Status ──────────────────────────"
+if command -v sestatus &>/dev/null; then
+    sestatus | sed 's/^/  /'
+    MODE=$(getenforce 2>/dev/null || echo "unknown")
+    echo ""
+    echo "  Current mode: ${MODE}"
+    if [[ "${MODE}" == "Enforcing" ]]; then
+        echo "  [INFO] SELinux is ENFORCING — policies are actively blocking."
+    elif [[ "${MODE}" == "Permissive" ]]; then
+        echo "  [INFO] SELinux is PERMISSIVE — denials logged but not blocked."
+    fi
+else
+    echo "  SELinux not installed or sestatus not available."
+    exit 0
+fi
+
+echo ""
+
+# ---------- Recent AVC denials ----------
+echo "── Recent AVC Denials (last 1 hour) ────────"
+if command -v ausearch &>/dev/null; then
+    DENIALS=$(ausearch -m avc -ts recent 2>/dev/null | grep 'type=AVC' | tail -30)
+    if [[ -n "${DENIALS}" ]]; then
+        echo "  [WARN] Recent SELinux denials found:"
+        echo "${DENIALS}" | sed 's/^/  /'
+        echo ""
+        echo "  For human-readable output:"
+        ausearch -m avc -ts recent 2>/dev/null | audit2allow 2>/dev/null | head -30 | sed 's/^/  /' || \
+            echo "  (install policycoreutils-python-utils for audit2allow)"
+    else
+        echo "  [OK] No recent AVC denials found."
+    fi
+elif [[ -f /var/log/audit/audit.log ]]; then
+    DENIALS=$(grep 'type=AVC' /var/log/audit/audit.log | tail -20)
+    if [[ -n "${DENIALS}" ]]; then
+        echo "  [WARN] AVC denials in audit.log:"
+        echo "${DENIALS}" | sed 's/^/  /'
+    else
+        echo "  [OK] No AVC denials in audit.log."
+    fi
+else
+    echo "  Cannot read audit log (run as root for full access)."
+fi
+
+echo ""
+
+# ---------- Port labeling ----------
+echo "── SELinux Port Labels for ${PORT} ─────────"
+if command -v semanage &>/dev/null; then
+    LABEL=$(semanage port -l 2>/dev/null | grep -E "\b${PORT}\b" || echo "")
+    if [[ -n "${LABEL}" ]]; then
+        echo "  [OK ] Port ${PORT} has an SELinux label:"
+        echo "  ${LABEL}"
+    else
+        echo "  [WARN] Port ${PORT} has NO SELinux port label."
+        echo "  This may prevent processes from binding to it."
+        echo ""
+        echo "  Common port types for network services:"
+        echo "    http_port_t    : 80, 443, 8080, 8443"
+        echo "    ssh_port_t     : 22"
+        echo "    unreserved_port_t : ephemeral / custom ports"
+        echo ""
+        echo "  Fix options:"
+        echo "    Option A (label port as http-like):"
+        echo "      semanage port -a -t http_port_t -p tcp ${PORT}"
+        echo ""
+        echo "    Option B (label as unreserved port):"
+        echo "      semanage port -a -t unreserved_port_t -p tcp ${PORT}"
+        echo ""
+        echo "    Option C (temporary — allow all container networking):"
+        echo "      setsebool -P container_manage_cgroup on"
+        echo "      setsebool -P container_use_cephfs on"
+    fi
+else
+    echo "  semanage not available (install policycoreutils-python-utils)"
+fi
+
+echo ""
+
+# ---------- Podman SELinux booleans ----------
+echo "── SELinux Booleans for Container/Podman ───"
+PODMAN_BOOLEANS=(
+    "container_manage_cgroup"
+    "container_use_cephfs"
+    "container_connect_any"
+    "virt_use_nfs"
+    "virt_sandbox_use_netlink"
+    "virt_sandbox_use_all_caps"
+)
+
+for bool in "${PODMAN_BOOLEANS[@]}"; do
+    VAL=$(getsebool "${bool}" 2>/dev/null || echo "N/A")
+    printf "  %-40s : %s\n" "${bool}" "${VAL}"
+done
+
+echo ""
+echo "── nc Process SELinux Context ──────────────"
+if pgrep -x nc &>/dev/null || pgrep -x ncat &>/dev/null; then
+    ps auxZ 2>/dev/null | grep -E '\bnc\b|\bncat\b' | grep -v grep | sed 's/^/  /' || true
+else
+    echo "  nc/ncat not currently running."
+fi
+
+echo ""
+echo "── Quick Fixes If SELinux Is Blocking ──────"
+echo ""
+echo "  1. Temporarily set to Permissive to confirm SELinux is the cause:"
+echo "     setenforce 0"
+echo "     (run nc test — if it works, SELinux is the issue)"
+echo "     setenforce 1  # re-enable after test"
+echo ""
+echo "  2. Generate and apply a custom policy from denials:"
+echo "     ausearch -m avc -ts recent | audit2allow -M my_podman_policy"
+echo "     semodule -i my_podman_policy.pp"
+echo ""
+echo "  3. For Podman containers, apply the container_t label fix:"
+echo "     setsebool -P container_manage_cgroup on"
+echo "     setsebool -P container_connect_any on"
+echo ""
+echo "  See also: fixes/fix_selinux_podman.sh"
+echo "============================================="

--- a/network-test-scripts/diagnostics/full_diagnostic.sh
+++ b/network-test-scripts/diagnostics/full_diagnostic.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# full_diagnostic.sh - Run all network diagnostics for EC2 <-> Podman issues.
+# Run this on BOTH hosts and compare output.
+#
+# Usage: ./full_diagnostic.sh [TARGET_IP] [PORT]
+#   TARGET_IP  Remote host IP to include in connectivity checks (optional)
+#   PORT       Port to check specifically (optional, default: 9000)
+#
+# Output is written to a timestamped log file for easy sharing.
+
+set -uo pipefail
+
+TARGET_IP="${1:-}"
+PORT="${2:-9000}"
+LOGFILE="/tmp/network_diag_$(hostname -s)_$(date +%Y%m%d_%H%M%S).log"
+
+run_section() {
+    local title="$1"
+    local cmd="$2"
+    echo ""
+    echo "══════════════════════════════════════════════"
+    echo " ${title}"
+    echo "══════════════════════════════════════════════"
+    eval "${cmd}" 2>&1 || true
+}
+
+{
+echo "############################################"
+echo " FULL NETWORK DIAGNOSTIC REPORT"
+echo " Host    : $(hostname -f 2>/dev/null || hostname)"
+echo " IPs     : $(hostname -I)"
+echo " OS      : $(grep PRETTY_NAME /etc/os-release | cut -d= -f2 | tr -d '\"')"
+echo " Kernel  : $(uname -r)"
+echo " User    : $(id)"
+echo " Target  : ${TARGET_IP:-<not specified>}"
+echo " Port    : ${PORT}"
+echo " Time    : $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+echo "############################################"
+
+# ── System basics ──────────────────────────────
+run_section "NETWORK INTERFACES" "ip addr show"
+run_section "ROUTING TABLE" "ip route show"
+run_section "IP FORWARDING" "sysctl net.ipv4.ip_forward net.ipv4.conf.all.forwarding 2>/dev/null || cat /proc/sys/net/ipv4/ip_forward"
+
+# ── Listening ports ────────────────────────────
+run_section "LISTENING SOCKETS (ss)" "ss -tlnp 2>/dev/null || netstat -tlnp 2>/dev/null"
+
+# ── Firewalld ──────────────────────────────────
+if systemctl is-active --quiet firewalld 2>/dev/null; then
+    run_section "FIREWALLD STATUS" "firewall-cmd --state && firewall-cmd --list-all"
+    run_section "FIREWALLD ALL ZONES" "firewall-cmd --list-all-zones 2>/dev/null"
+    run_section "FIREWALLD MASQUERADE" "firewall-cmd --zone=public --query-masquerade 2>/dev/null && echo 'masquerade: ENABLED' || echo 'masquerade: DISABLED'"
+else
+    echo ""
+    echo "══ FIREWALLD: not active on this host ══"
+fi
+
+# ── iptables ───────────────────────────────────
+run_section "IPTABLES FILTER" "iptables -L -n -v --line-numbers 2>/dev/null || echo 'iptables not available'"
+run_section "IPTABLES NAT" "iptables -t nat -L -n -v 2>/dev/null || echo 'iptables nat not available'"
+run_section "NFTABLES" "nft list ruleset 2>/dev/null || echo 'nftables not available or no rules'"
+
+# ── Port-specific check ────────────────────────
+run_section "PORT ${PORT} FIREWALL RULES" "
+iptables -L -n -v 2>/dev/null | grep -E ':${PORT}|dpt:${PORT}|ACCEPT|DROP|REJECT' | head -30 || true
+nft list ruleset 2>/dev/null | grep -E '${PORT}' | head -30 || true
+"
+
+# ── SELinux ────────────────────────────────────
+run_section "SELINUX STATUS" "sestatus 2>/dev/null || echo 'SELinux not installed'"
+run_section "SELINUX RECENT DENIALS" "
+if command -v ausearch &>/dev/null; then
+    ausearch -m avc -ts recent 2>/dev/null | tail -40 || echo 'No recent AVC denials'
+elif [ -f /var/log/audit/audit.log ]; then
+    grep 'type=AVC' /var/log/audit/audit.log | tail -20
+else
+    echo 'audit log not accessible'
+fi"
+run_section "SELINUX PORT LABELS (${PORT})" "
+semanage port -l 2>/dev/null | grep -E \"^Name|${PORT}\" | head -20 || echo 'semanage not available'"
+
+# ── Podman (if present) ────────────────────────
+if command -v podman &>/dev/null; then
+    run_section "PODMAN VERSION & INFO" "podman version && echo '---' && podman info | grep -E 'network|rootless|cgroupManager|Backend|version'"
+    run_section "PODMAN RUNNING CONTAINERS" "podman ps -a"
+    run_section "PODMAN PORT MAPPINGS" "
+for c in \$(podman ps --format '{{.Names}}' 2>/dev/null); do
+    echo \"Container: \$c\"
+    podman port \"\$c\" 2>/dev/null | sed 's/^/  /' || echo '  (no ports)'
+done"
+    run_section "PODMAN NETWORKS" "podman network ls && echo '---' && podman network inspect --all 2>/dev/null | python3 -m json.tool 2>/dev/null | head -80"
+    run_section "PODMAN CONTAINER LOGS (last 30 lines each)" "
+for c in \$(podman ps --format '{{.Names}}' 2>/dev/null); do
+    echo \"=== \$c ===\"
+    podman logs --tail 30 \"\$c\" 2>&1 || true
+done"
+    run_section "SLIRP4NETNS / PASTA PROCESSES" "
+ps aux | grep -E 'slirp4netns|pasta|passt' | grep -v grep || echo 'Not running'"
+else
+    echo ""
+    echo "══ PODMAN: not installed on this host ══"
+fi
+
+# ── Connectivity test to target ────────────────
+if [[ -n "${TARGET_IP}" ]]; then
+    run_section "PING TO TARGET ${TARGET_IP}" "ping -c 3 -W 2 ${TARGET_IP} 2>&1 || echo 'ping failed (ICMP may be blocked)'"
+    run_section "NC CONNECT TO ${TARGET_IP}:${PORT}" "nc -zv -w 5 ${TARGET_IP} ${PORT} 2>&1 && echo 'PORT OPEN' || echo 'PORT CLOSED/FILTERED'"
+    run_section "TRACEROUTE TO ${TARGET_IP}" "
+if command -v traceroute &>/dev/null; then
+    traceroute -m 10 ${TARGET_IP} 2>&1
+elif command -v tracepath &>/dev/null; then
+    tracepath ${TARGET_IP} 2>&1
+else
+    echo 'traceroute/tracepath not available'
+fi"
+fi
+
+echo ""
+echo "############################################"
+echo " END OF REPORT"
+echo " Saved to: ${LOGFILE}"
+echo "############################################"
+
+} 2>&1 | tee "${LOGFILE}"
+
+echo ""
+echo "Full report saved to: ${LOGFILE}"
+echo "Share this file with your team for remote debugging."

--- a/network-test-scripts/diagnostics/tcpdump_capture.sh
+++ b/network-test-scripts/diagnostics/tcpdump_capture.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# tcpdump_capture.sh - Capture traffic on a specific port to verify whether
+# packets are arriving / leaving the host or being dropped by the kernel.
+#
+# KEY INSIGHT:
+#   tcpdump captures at the NIC BEFORE iptables/nftables processes the packet.
+#   If tcpdump SEES the packet but nc DOESN'T receive it → firewall is dropping it.
+#   If tcpdump DOESN'T see the packet → issue is upstream (SG, routing, Podman NAT).
+#
+# Run this on EITHER host while running the nc test from the other side.
+#
+# Usage: ./tcpdump_capture.sh [PORT] [INTERFACE] [DURATION_SECS]
+#   PORT       Port to capture (default: 9000)
+#   INTERFACE  Network interface (default: auto-detected)
+#   DURATION   How long to capture in seconds (default: 30)
+#
+# Requires: tcpdump (sudo/root), or run as root.
+
+set -uo pipefail
+
+PORT="${1:-9000}"
+IFACE="${2:-}"
+DURATION="${3:-30}"
+CAPFILE="/tmp/capture_port${PORT}_$(date +%Y%m%d_%H%M%S).pcap"
+
+echo "============================================="
+echo " TCPDUMP PACKET CAPTURE"
+echo "============================================="
+echo " Port      : ${PORT}"
+echo " Duration  : ${DURATION}s"
+echo " Capture   : ${CAPFILE}"
+echo "============================================="
+echo ""
+
+# ---------- Auto-detect interface ----------
+if [[ -z "${IFACE}" ]]; then
+    # Prefer the primary default route interface
+    IFACE=$(ip route show default 2>/dev/null | awk '/default/ {print $5}' | head -1)
+    if [[ -z "${IFACE}" ]]; then
+        IFACE=$(ip link show | awk -F': ' '/^[0-9]+: [^lo]/{print $2}' | head -1)
+    fi
+    echo "[INFO] Auto-detected interface: ${IFACE}"
+fi
+
+if [[ -z "${IFACE}" ]]; then
+    echo "[ERROR] Could not detect network interface. Specify it as the 2nd argument."
+    exit 1
+fi
+
+echo "[INFO] Interface IP: $(ip addr show "${IFACE}" | grep 'inet ' | awk '{print $2}')"
+echo ""
+echo "[INFO] Starting capture for ${DURATION}s..."
+echo "[INFO] While this runs, trigger the nc test from the other host."
+echo ""
+echo "──── LIVE OUTPUT ────────────────────────────"
+
+# Capture on the main interface AND loopback (for local traffic)
+# -n: no DNS resolution  -v: verbose  -l: line-buffered
+timeout "${DURATION}" tcpdump -i "${IFACE}" -n -l -v \
+    "tcp port ${PORT}" 2>&1 | tee /tmp/tcpdump_live_$$.txt || true
+
+echo "──── END LIVE OUTPUT ─────────────────────────"
+echo ""
+
+# Save full pcap for offline analysis
+echo "[INFO] Saving full pcap file..."
+timeout "${DURATION}" tcpdump -i "${IFACE}" -n -w "${CAPFILE}" \
+    "tcp port ${PORT}" 2>/dev/null &
+TCPDUMP_PID=$!
+sleep "${DURATION}"
+kill "${TCPDUMP_PID}" 2>/dev/null || true
+wait "${TCPDUMP_PID}" 2>/dev/null || true
+
+echo ""
+echo "============================================="
+echo " ANALYSIS"
+echo "============================================="
+
+LIVE_LOG="/tmp/tcpdump_live_$$.txt"
+SYN_COUNT=$(grep -c 'Flags \[S\]' "${LIVE_LOG}" 2>/dev/null || echo 0)
+SYNACK_COUNT=$(grep -c 'Flags \[S\.\]' "${LIVE_LOG}" 2>/dev/null || echo 0)
+RST_COUNT=$(grep -c 'Flags \[R' "${LIVE_LOG}" 2>/dev/null || echo 0)
+DATA_COUNT=$(grep -c 'length [1-9]' "${LIVE_LOG}" 2>/dev/null || echo 0)
+
+echo " SYN packets seen     : ${SYN_COUNT}"
+echo " SYN-ACK packets seen : ${SYNACK_COUNT}"
+echo " RST packets seen     : ${RST_COUNT}"
+echo " Data packets seen    : ${DATA_COUNT}"
+echo ""
+
+if [[ "${SYN_COUNT}" -gt 0 && "${SYNACK_COUNT}" -eq 0 ]]; then
+    echo "[DIAGNOSIS] SYN packets arriving but NO SYN-ACK from this host."
+    echo "  → The OS received the SYN but something is preventing the response."
+    echo "  → Likely causes:"
+    echo "    a) firewalld/iptables DROP rule on port ${PORT}"
+    echo "    b) SELinux denying the bind/accept"
+    echo "    c) nc not listening (bound to 127.0.0.1 or wrong port)"
+    echo ""
+    echo "  → Run: diagnostics/check_firewall.sh ${PORT}"
+    echo "  → Run: diagnostics/check_selinux.sh"
+elif [[ "${SYN_COUNT}" -eq 0 ]]; then
+    echo "[DIAGNOSIS] NO SYN packets seen at all on port ${PORT}."
+    echo "  → Packets are not arriving at this host."
+    echo "  → Likely causes:"
+    echo "    a) AWS Security Group blocking inbound port ${PORT}"
+    echo "    b) Wrong destination IP being used by the sender"
+    echo "    c) If source is Podman: container traffic not leaving RHEL9 host"
+    echo "       (Podman NAT / masquerade not configured)"
+    echo ""
+    echo "  → Run tcpdump_capture.sh on the SENDER host to see if packets leave."
+elif [[ "${SYNACK_COUNT}" -gt 0 && "${DATA_COUNT}" -eq 0 ]]; then
+    echo "[DIAGNOSIS] Handshake completing (SYN+SYN-ACK) but no data transferred."
+    echo "  → TCP connection is working! The nc application may not be sending data."
+    echo "  → This is typically SUCCESS for a basic port test."
+else
+    echo "[DIAGNOSIS] Traffic detected — review the output above for anomalies."
+fi
+
+rm -f "${LIVE_LOG}"
+
+echo ""
+echo " Full pcap saved to : ${CAPFILE}"
+echo " Analyze offline    : tcpdump -r ${CAPFILE} -n -v"
+echo " View in Wireshark  : copy ${CAPFILE} to your workstation"
+echo "============================================="

--- a/network-test-scripts/ec2-to-ec2/client.sh
+++ b/network-test-scripts/ec2-to-ec2/client.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# client.sh - Test TCP connectivity from this EC2 to a remote host/port.
+# Run this on the SENDER EC2.
+#
+# Usage: ./client.sh <HOST> [PORT] [TIMEOUT_SECS]
+#   HOST          IP or hostname of the remote EC2
+#   PORT          Port to connect to (default: 8080)
+#   TIMEOUT_SECS  Connection timeout in seconds (default: 5)
+#
+# Example:
+#   ./client.sh 10.0.1.50 9000
+#   ./client.sh 10.0.1.50 9000 10
+
+set -euo pipefail
+
+HOST="${1:-}"
+PORT="${2:-8080}"
+TIMEOUT="${3:-5}"
+
+if [[ -z "${HOST}" ]]; then
+    echo "Usage: $0 <HOST> [PORT] [TIMEOUT_SECS]"
+    exit 1
+fi
+
+echo "============================================="
+echo " EC2 NC CLIENT TEST"
+echo "============================================="
+echo " Target  : ${HOST}:${PORT}"
+echo " Timeout : ${TIMEOUT}s"
+echo " From    : $(hostname) ($(hostname -I | awk '{print $1}'))"
+echo " Time    : $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+echo "============================================="
+echo ""
+
+# ---------- DNS check ----------
+echo "[STEP 1] DNS / reachability pre-check"
+if command -v ping &>/dev/null; then
+    if ping -c 2 -W 2 "${HOST}" &>/dev/null; then
+        echo "  [OK ] ping to ${HOST} succeeded"
+    else
+        echo "  [WARN] ping to ${HOST} failed (ICMP may be blocked — continuing)"
+    fi
+fi
+
+# ---------- nc connect test ----------
+echo ""
+echo "[STEP 2] nc TCP connect test  (${HOST}:${PORT}, timeout=${TIMEOUT}s)"
+if nc -vz -w "${TIMEOUT}" "${HOST}" "${PORT}" 2>&1; then
+    echo ""
+    echo "[RESULT] SUCCESS — port ${PORT} is open and accepting connections."
+else
+    echo ""
+    echo "[RESULT] FAILURE — could not connect to ${HOST}:${PORT} within ${TIMEOUT}s."
+    echo ""
+    echo "Common causes:"
+    echo "  1. firewalld/iptables is blocking the port on the receiver"
+    echo "  2. AWS Security Group does not allow inbound on port ${PORT}"
+    echo "  3. nc server is not running (or bound to 127.0.0.1 only)"
+    echo "  4. If source is a Podman container: masquerade / port-publish issue"
+    echo ""
+    echo "Run diagnostics/full_diagnostic.sh on both hosts for details."
+    exit 1
+fi
+
+# ---------- send test payload ----------
+echo ""
+echo "[STEP 3] Sending test payload over connection..."
+echo "HELLO_FROM_$(hostname)_AT_$(date -u '+%H:%M:%SZ')" | \
+    nc -w "${TIMEOUT}" "${HOST}" "${PORT}" 2>&1 && \
+    echo "  [OK ] Payload sent." || \
+    echo "  [WARN] Payload send failed (server may not be in persistent mode)"

--- a/network-test-scripts/ec2-to-ec2/multi_port_test.sh
+++ b/network-test-scripts/ec2-to-ec2/multi_port_test.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# multi_port_test.sh - Scan a list of ports against a remote host.
+# Useful for quickly finding which ports are open vs blocked.
+# Run this on the SENDER EC2.
+#
+# Usage: ./multi_port_test.sh <HOST> [PORT_LIST] [TIMEOUT_SECS]
+#   HOST        Target IP or hostname
+#   PORT_LIST   Comma-separated ports (default: 80,443,8080,8443,9000,9090,5000,6000)
+#   TIMEOUT     Per-port timeout in seconds (default: 3)
+#
+# Example:
+#   ./multi_port_test.sh 10.0.1.50
+#   ./multi_port_test.sh 10.0.1.50 9000,9001,9002
+#   ./multi_port_test.sh 10.0.1.50 8080,9000,5432 5
+
+set -euo pipefail
+
+HOST="${1:-}"
+PORT_LIST="${2:-80,443,8080,8443,9000,9090,5000,6000}"
+TIMEOUT="${3:-3}"
+
+if [[ -z "${HOST}" ]]; then
+    echo "Usage: $0 <HOST> [PORT_LIST] [TIMEOUT_SECS]"
+    exit 1
+fi
+
+IFS=',' read -ra PORTS <<< "${PORT_LIST}"
+
+echo "============================================="
+echo " MULTI-PORT TCP SCAN"
+echo "============================================="
+echo " Target  : ${HOST}"
+echo " Ports   : ${PORT_LIST}"
+echo " Timeout : ${TIMEOUT}s / port"
+echo " Time    : $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+echo "============================================="
+echo ""
+
+OPEN=()
+CLOSED=()
+
+for PORT in "${PORTS[@]}"; do
+    PORT="${PORT// /}"  # strip spaces
+    printf "  Testing port %-6s ... " "${PORT}"
+    if nc -z -w "${TIMEOUT}" "${HOST}" "${PORT}" 2>/dev/null; then
+        echo "OPEN"
+        OPEN+=("${PORT}")
+    else
+        echo "CLOSED / FILTERED"
+        CLOSED+=("${PORT}")
+    fi
+done
+
+echo ""
+echo "============================================="
+echo " SUMMARY"
+echo "============================================="
+echo " OPEN   (${#OPEN[@]}): ${OPEN[*]:-none}"
+echo " CLOSED (${#CLOSED[@]}): ${CLOSED[*]:-none}"
+echo ""
+
+if [[ ${#CLOSED[@]} -gt 0 ]]; then
+    echo "[ACTION] For each closed port on the receiver EC2, check:"
+    echo "  firewall-cmd --list-all"
+    echo "  iptables -L -n -v | grep <PORT>"
+    echo "  Also verify AWS Security Group inbound rules."
+fi

--- a/network-test-scripts/ec2-to-ec2/server.sh
+++ b/network-test-scripts/ec2-to-ec2/server.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# server.sh - Start an nc listener on a specified port for EC2-to-EC2 testing.
+# Run this on the RECEIVER EC2 (RHEL8).
+#
+# Usage: ./server.sh [PORT] [BIND_ADDR]
+#   PORT        Port to listen on (default: 8080)
+#   BIND_ADDR   Address to bind to (default: 0.0.0.0 = all interfaces)
+#
+# Example:
+#   ./server.sh 9000
+#   ./server.sh 9000 0.0.0.0
+
+set -euo pipefail
+
+PORT="${1:-8080}"
+BIND_ADDR="${2:-0.0.0.0}"
+
+echo "============================================="
+echo " EC2 NC LISTENER"
+echo "============================================="
+echo " Listening on : ${BIND_ADDR}:${PORT}"
+echo " Timestamp    : $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+echo " Hostname     : $(hostname -f 2>/dev/null || hostname)"
+echo " Kernel       : $(uname -r)"
+echo "============================================="
+echo ""
+echo "[INFO] If nc receives a connection you will see data below."
+echo "[INFO] Press Ctrl+C to stop."
+echo ""
+
+# Detect nc flavour (ncat vs traditional netcat)
+if nc --version 2>&1 | grep -qi ncat; then
+    # ncat (nmap package) – preferred on RHEL
+    exec nc -lvk --source-port "${PORT}" -s "${BIND_ADDR}" 2>&1
+else
+    # Traditional netcat (may not support -s)
+    exec nc -lvp "${PORT}" 2>&1
+fi

--- a/network-test-scripts/ec2-to-podman/check_podman_config.sh
+++ b/network-test-scripts/ec2-to-podman/check_podman_config.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# check_podman_config.sh - Inspect all Podman networking config relevant to
+# external connectivity. Run this on the RHEL9 EC2 that runs the container.
+#
+# Usage: ./check_podman_config.sh [CONTAINER_NAME_OR_ID]
+#   CONTAINER_NAME_OR_ID  Optional: narrow checks to a specific container
+
+set -uo pipefail
+
+CONTAINER="${1:-}"
+
+echo "============================================="
+echo " PODMAN NETWORK CONFIGURATION CHECK"
+echo "============================================="
+echo " Host     : $(hostname) / $(hostname -I | awk '{print $1}')"
+echo " OS       : $(grep PRETTY_NAME /etc/os-release | cut -d= -f2 | tr -d '\"')"
+echo " Kernel   : $(uname -r)"
+echo " Podman   : $(podman --version)"
+echo " User     : $(id)"
+echo " Time     : $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+echo "============================================="
+echo ""
+
+# ---------- Podman info ----------
+echo "── Podman system info ──────────────────────"
+podman info --format json 2>/dev/null | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+host = d.get('host', {})
+print(f\"  Network backend : {d.get('plugins', {}).get('network', 'unknown')}\")
+print(f\"  CGroup manager  : {host.get('cgroupManager', 'unknown')}\")
+print(f\"  rootless        : {host.get('security', {}).get('rootless', 'unknown')}\")
+" 2>/dev/null || podman info | grep -E 'network|rootless|cgroupManager' | sed 's/^/  /'
+
+echo ""
+
+# ---------- Running containers ----------
+echo "── Running containers ──────────────────────"
+if [[ -n "${CONTAINER}" ]]; then
+    podman ps --filter "name=${CONTAINER}" --format "table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null || \
+    podman ps | grep "${CONTAINER}"
+else
+    podman ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null || podman ps
+fi
+
+echo ""
+
+# ---------- Port mappings ----------
+echo "── Port mappings ───────────────────────────"
+if [[ -n "${CONTAINER}" ]]; then
+    echo "  Container: ${CONTAINER}"
+    podman port "${CONTAINER}" 2>/dev/null | sed 's/^/    /' || echo "  [WARN] Could not get ports for ${CONTAINER}"
+else
+    for cname in $(podman ps --format '{{.Names}}' 2>/dev/null); do
+        echo "  Container: ${cname}"
+        podman port "${cname}" 2>/dev/null | sed 's/^/    /' || echo "    (no ports)"
+    done
+fi
+
+echo ""
+
+# ---------- Network list ----------
+echo "── Podman networks ─────────────────────────"
+podman network ls 2>/dev/null | sed 's/^/  /'
+
+echo ""
+
+# ---------- Network inspect ----------
+echo "── Network inspect (all) ───────────────────"
+for netname in $(podman network ls --format '{{.Name}}' 2>/dev/null); do
+    echo "  --- Network: ${netname} ---"
+    podman network inspect "${netname}" 2>/dev/null | python3 -c "
+import json, sys
+nets = json.load(sys.stdin)
+for n in nets:
+    print(f\"    driver    : {n.get('driver', 'unknown')}\")
+    print(f\"    dns_enabled: {n.get('dns_enabled', 'unknown')}\")
+    for sub in n.get('subnets', []):
+        print(f\"    subnet    : {sub.get('subnet', '')}\")
+        print(f\"    gateway   : {sub.get('gateway', '')}\")
+" 2>/dev/null || echo "  (parse error)"
+done
+
+echo ""
+
+# ---------- Rootless check ----------
+echo "── Rootless / slirp4netns / pasta ──────────"
+if id | grep -qv 'uid=0'; then
+    echo "  [WARN] Running as non-root. Rootless Podman uses slirp4netns or pasta."
+    echo "         External ports are proxied through the host userspace, which"
+    echo "         means they may NOT show in 'ss -tlnp' but still work."
+    echo "  Check: podman info | grep -i 'network\|slirp'"
+    if pgrep -x slirp4netns &>/dev/null; then
+        echo "  [INFO] slirp4netns process is running."
+    fi
+    if pgrep -x pasta &>/dev/null; then
+        echo "  [INFO] pasta (passt) process is running."
+    fi
+else
+    echo "  [INFO] Running as root. Podman uses kernel-level network namespaces."
+    echo "         Ports WILL appear in 'ss -tlnp'."
+fi
+
+echo ""
+
+# ---------- Host port listen check ----------
+echo "── Host listening ports (ss) ───────────────"
+if [[ -n "${CONTAINER}" ]]; then
+    PORTS_RAW=$(podman port "${CONTAINER}" 2>/dev/null | awk -F'[ :]' '{print $(NF)}')
+    for p in ${PORTS_RAW}; do
+        printf "  Port %-6s : " "${p}"
+        if ss -tlnp 2>/dev/null | grep -q ":${p}"; then
+            echo "LISTENING (visible to kernel)"
+            ss -tlnp | grep ":${p}" | sed 's/^/    /'
+        else
+            echo "not in ss (may be proxied via rootless Podman)"
+        fi
+    done
+else
+    echo "  (specify a container name for targeted port check)"
+    ss -tlnp 2>/dev/null | grep -E 'LISTEN|State' | head -20 | sed 's/^/  /'
+fi
+
+echo ""
+echo "── Kernel IP forwarding ────────────────────"
+FWD=$(cat /proc/sys/net/ipv4/ip_forward 2>/dev/null || echo "unknown")
+echo "  ip_forward : ${FWD}"
+if [[ "${FWD}" != "1" ]]; then
+    echo "  [WARN] IP forwarding is disabled! Podman container traffic cannot route."
+    echo "  Fix:   echo 1 > /proc/sys/net/ipv4/ip_forward"
+    echo "         sysctl -w net.ipv4.ip_forward=1"
+fi
+
+echo ""
+echo "============================================="
+echo " Done. Review any [WARN] items above."
+echo "============================================="

--- a/network-test-scripts/ec2-to-podman/client_test.sh
+++ b/network-test-scripts/ec2-to-podman/client_test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# client_test.sh - Test connectivity from a plain EC2 (RHEL8) to a Podman
+# container running on another EC2 (RHEL9).
+#
+# Run this on the RHEL8 EC2.
+#
+# Usage: ./client_test.sh <RHEL9_HOST_IP> [PORT] [TIMEOUT_SECS]
+#   RHEL9_HOST_IP  Public or private IP of the RHEL9 EC2
+#   PORT           Port published from the Podman container (default: 9000)
+#   TIMEOUT        Connection timeout (default: 5)
+#
+# Example:
+#   ./client_test.sh 10.0.2.100 9000
+
+set -euo pipefail
+
+HOST="${1:-}"
+PORT="${2:-9000}"
+TIMEOUT="${3:-5}"
+ATTEMPTS=3
+
+if [[ -z "${HOST}" ]]; then
+    echo "Usage: $0 <RHEL9_HOST_IP> [PORT] [TIMEOUT_SECS]"
+    exit 1
+fi
+
+echo "============================================="
+echo " EC2 -> PODMAN CONTAINER CONNECTIVITY TEST"
+echo "============================================="
+echo " Target container host : ${HOST}"
+echo " Published port        : ${PORT}"
+echo " Timeout per attempt   : ${TIMEOUT}s"
+echo " Attempts              : ${ATTEMPTS}"
+echo " Source host           : $(hostname) ($(hostname -I | awk '{print $1}'))"
+echo " Time                  : $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+echo "============================================="
+echo ""
+
+PASS=0
+FAIL=0
+
+for i in $(seq 1 "${ATTEMPTS}"); do
+    printf "[Attempt %d/%d] Connecting to %s:%s ... " "${i}" "${ATTEMPTS}" "${HOST}" "${PORT}"
+    if nc -z -w "${TIMEOUT}" "${HOST}" "${PORT}" 2>/dev/null; then
+        echo "SUCCESS"
+        PASS=$((PASS + 1))
+    else
+        echo "FAILED"
+        FAIL=$((FAIL + 1))
+    fi
+    sleep 1
+done
+
+echo ""
+echo "============================================="
+echo " RESULT: ${PASS}/${ATTEMPTS} attempts succeeded"
+echo "============================================="
+echo ""
+
+if [[ "${PASS}" -eq 0 ]]; then
+    echo "[DIAGNOSIS] All attempts failed. Likely causes and fixes:"
+    echo ""
+    echo "  ON THE RHEL9 HOST (Podman side):"
+    echo "  ─────────────────────────────────────────"
+    echo "  1. Port not published to 0.0.0.0"
+    echo "     Check:  podman port <container_name>"
+    echo "     Fix:    Re-run container with: -p 0.0.0.0:${PORT}:${PORT}"
+    echo ""
+    echo "  2. firewalld blocking the port on the RHEL9 host"
+    echo "     Check:  firewall-cmd --list-all"
+    echo "     Fix:    firewall-cmd --zone=public --add-port=${PORT}/tcp --permanent && firewall-cmd --reload"
+    echo ""
+    echo "  3. Masquerade not enabled (required for Podman -> external)"
+    echo "     Check:  firewall-cmd --zone=public --query-masquerade"
+    echo "     Fix:    firewall-cmd --zone=public --add-masquerade --permanent && firewall-cmd --reload"
+    echo ""
+    echo "  4. Rootless Podman using slirp4netns (no kernel-level bind)"
+    echo "     Check:  podman info | grep -i network"
+    echo "     Fix:    Run container as root OR use --network=host"
+    echo "             sudo podman run --network=host ..."
+    echo ""
+    echo "  5. SELinux blocking the port"
+    echo "     Check:  ausearch -m avc -ts recent | grep ${PORT}"
+    echo "             grep 'denied' /var/log/audit/audit.log | grep ${PORT}"
+    echo "     Fix:    semanage port -a -t http_port_t -p tcp ${PORT}"
+    echo "             OR: setsebool -P container_manage_cgroup on"
+    echo ""
+    echo "  ON THE RHEL8 HOST (receiver side — if roles are reversed):"
+    echo "  ─────────────────────────────────────────"
+    echo "  6. AWS Security Group does not allow inbound port ${PORT}"
+    echo "     Fix:    Add inbound rule in EC2 console for port ${PORT}"
+    echo ""
+    echo "  Run: diagnostics/full_diagnostic.sh on both hosts"
+    echo "  Run: diagnostics/tcpdump_capture.sh ${PORT} on the RHEL9 host"
+    echo "       to see if packets are leaving the host."
+    exit 1
+elif [[ "${PASS}" -lt "${ATTEMPTS}" ]]; then
+    echo "[WARN] Intermittent connectivity. Possible packet loss or connection"
+    echo "       instability. Check firewall rules and Podman network stability."
+else
+    echo "[OK] All attempts succeeded!"
+    echo ""
+    echo "[STEP] Sending test message..."
+    PAYLOAD="HELLO_FROM_$(hostname)_AT_$(date -u '+%H:%M:%SZ')"
+    echo "${PAYLOAD}" | nc -w "${TIMEOUT}" "${HOST}" "${PORT}" 2>&1 && \
+        echo "  [OK ] Sent: ${PAYLOAD}" || \
+        echo "  [WARN] Message send failed (nc server may need -e option)"
+fi

--- a/network-test-scripts/ec2-to-podman/podman_server_setup.sh
+++ b/network-test-scripts/ec2-to-podman/podman_server_setup.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# podman_server_setup.sh - Launch a lightweight test container on the RHEL9 EC2
+# that runs an nc listener so external hosts can connect to it.
+#
+# Run this on the RHEL9 EC2 that hosts the Podman container.
+#
+# Usage: ./podman_server_setup.sh [HOST_PORT] [CONTAINER_PORT] [IMAGE]
+#   HOST_PORT       Port exposed on the RHEL9 EC2 host (default: 9000)
+#   CONTAINER_PORT  Port nc listens on inside the container (default: 9000)
+#   IMAGE           Container image to use (default: registry.access.redhat.com/ubi9/ubi-minimal)
+#
+# Example:
+#   ./podman_server_setup.sh 9000 9000
+#   ./podman_server_setup.sh 8080 8080 debian:12
+
+set -euo pipefail
+
+HOST_PORT="${1:-9000}"
+CONTAINER_PORT="${2:-9000}"
+IMAGE="${3:-registry.access.redhat.com/ubi9/ubi-minimal}"
+CONTAINER_NAME="nc-test-server"
+
+echo "============================================="
+echo " PODMAN NC SERVER SETUP"
+echo "============================================="
+echo " Image          : ${IMAGE}"
+echo " Host port      : ${HOST_PORT}"
+echo " Container port : ${CONTAINER_PORT}"
+echo " Container name : ${CONTAINER_NAME}"
+echo " Host           : $(hostname) ($(hostname -I | awk '{print $1}'))"
+echo " Podman version : $(podman --version)"
+echo "============================================="
+echo ""
+
+# ---------- Cleanup any existing container ----------
+echo "[STEP 1] Removing any existing '${CONTAINER_NAME}' container..."
+podman rm -f "${CONTAINER_NAME}" 2>/dev/null && echo "  [OK ] Removed old container." || echo "  [INFO] No old container to remove."
+
+# ---------- Determine nc binary in image ----------
+# ubi-minimal uses microdnf; debian images have netcat-openbsd
+echo ""
+echo "[STEP 2] Pulling image '${IMAGE}'..."
+podman pull "${IMAGE}"
+
+# ---------- Detect nc availability in image ----------
+NC_CMD=""
+for candidate in "nc" "ncat" "netcat"; do
+    if podman run --rm "${IMAGE}" which "${candidate}" &>/dev/null 2>&1; then
+        NC_CMD="${candidate}"
+        break
+    fi
+done
+
+if [[ -z "${NC_CMD}" ]]; then
+    echo ""
+    echo "[WARN] No nc/ncat found in ${IMAGE}."
+    echo "       Attempting to install nmap-ncat via microdnf (UBI images)..."
+    # Create a derived image with ncat installed
+    DOCKERFILE=$(mktemp --suffix=.Containerfile)
+    cat > "${DOCKERFILE}" <<CONTAINERFILE
+FROM ${IMAGE}
+RUN microdnf install -y nmap-ncat 2>/dev/null || \
+    apt-get update -y && apt-get install -y netcat-openbsd 2>/dev/null || \
+    yum install -y nmap-ncat 2>/dev/null
+CONTAINERFILE
+    podman build -t nc-test-image -f "${DOCKERFILE}" .
+    rm -f "${DOCKERFILE}"
+    IMAGE="nc-test-image"
+    NC_CMD="ncat"
+fi
+
+echo "  [OK ] Using nc command: ${NC_CMD}"
+
+# ---------- Launch container ----------
+echo ""
+echo "[STEP 3] Launching container..."
+echo "  Binding 0.0.0.0:${HOST_PORT} -> container:${CONTAINER_PORT}"
+echo ""
+
+# CRITICAL: bind to 0.0.0.0 on the host, not 127.0.0.1
+# Use --network=host mode as fallback flag shown in comments
+podman run -d \
+    --name "${CONTAINER_NAME}" \
+    -p "0.0.0.0:${HOST_PORT}:${CONTAINER_PORT}/tcp" \
+    "${IMAGE}" \
+    sh -c "${NC_CMD} -lvk -p ${CONTAINER_PORT} -e /bin/sh 2>&1 | while IFS= read -r line; do echo \"[CONTAINER] \$line\"; done"
+
+echo ""
+echo "[STEP 4] Verifying container is running..."
+sleep 2
+if podman ps --filter "name=${CONTAINER_NAME}" --format "{{.Names}}" | grep -q "${CONTAINER_NAME}"; then
+    echo "  [OK ] Container '${CONTAINER_NAME}' is running."
+else
+    echo "  [ERROR] Container failed to start. Logs:"
+    podman logs "${CONTAINER_NAME}" 2>&1 || true
+    exit 1
+fi
+
+echo ""
+echo "[STEP 5] Port mapping verification..."
+podman port "${CONTAINER_NAME}"
+
+echo ""
+echo "[STEP 6] Host-level listen verification..."
+if ss -tlnp 2>/dev/null | grep -q ":${HOST_PORT}"; then
+    echo "  [OK ] Port ${HOST_PORT} is listening on the host."
+    ss -tlnp | grep ":${HOST_PORT}"
+else
+    echo "  [WARN] Port ${HOST_PORT} not visible in ss output."
+    echo "         This can happen with rootless Podman using slirp4netns."
+    echo "         Check with: sudo ss -tlnp | grep ${HOST_PORT}"
+fi
+
+echo ""
+echo "============================================="
+echo " CONTAINER IS READY"
+echo "============================================="
+echo " From the RHEL8 EC2, run:"
+echo "   ./ec2-to-podman/client_test.sh $(hostname -I | awk '{print $1}') ${HOST_PORT}"
+echo ""
+echo " To view container logs:"
+echo "   podman logs -f ${CONTAINER_NAME}"
+echo ""
+echo " To stop the container:"
+echo "   podman rm -f ${CONTAINER_NAME}"
+echo "============================================="

--- a/network-test-scripts/fixes/fix_podman_firewall.sh
+++ b/network-test-scripts/fixes/fix_podman_firewall.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# fix_podman_firewall.sh - Fix firewalld and iptables/nftables configuration
+# so that traffic from a Podman container on RHEL9 can reach external EC2s,
+# AND so that external hosts can connect to the published container port.
+#
+# Run on the RHEL9 EC2 that hosts the Podman container (as root or with sudo).
+#
+# The symptom this fixes:
+#   - tcpdump sees packets arriving on the RHEL9 host
+#   - But nc inside / connecting to the container still times out
+#   - firewall-cmd --list-all doesn't show the port as allowed
+#
+# Usage: ./fix_podman_firewall.sh [PORT] [ZONE]
+#   PORT  Port to open (default: 9000)
+#   ZONE  firewalld zone (default: public)
+
+set -euo pipefail
+
+PORT="${1:-9000}"
+ZONE="${2:-public}"
+PROTO="tcp"
+
+echo "============================================="
+echo " PODMAN FIREWALL FIX"
+echo "============================================="
+echo " Port     : ${PORT}/${PROTO}"
+echo " Zone     : ${ZONE}"
+echo " Host     : $(hostname)"
+echo " Run as   : $(id)"
+echo "============================================="
+echo ""
+
+if [[ "${EUID}" -ne 0 ]]; then
+    echo "[WARN] Not running as root. Commands will use sudo."
+    SUDO="sudo"
+else
+    SUDO=""
+fi
+
+CHANGES=()
+
+# ── Step 1: Enable masquerade ─────────────────────────────────────────────────
+echo "[STEP 1] Enable masquerade in zone '${ZONE}'..."
+echo "  Masquerade allows container NAT traffic to leave the host as the host IP."
+if ${SUDO} firewall-cmd --zone="${ZONE}" --query-masquerade 2>/dev/null; then
+    echo "  [OK ] Masquerade already enabled."
+else
+    ${SUDO} firewall-cmd --zone="${ZONE}" --add-masquerade --permanent
+    CHANGES+=("masquerade enabled in zone ${ZONE}")
+    echo "  [OK ] Masquerade added (permanent)."
+fi
+
+# ── Step 2: Open the published port ──────────────────────────────────────────
+echo ""
+echo "[STEP 2] Open port ${PORT}/${PROTO} in zone '${ZONE}'..."
+if ${SUDO} firewall-cmd --zone="${ZONE}" --query-port="${PORT}/${PROTO}" 2>/dev/null; then
+    echo "  [OK ] Port ${PORT}/${PROTO} already open."
+else
+    ${SUDO} firewall-cmd --zone="${ZONE}" --add-port="${PORT}/${PROTO}" --permanent
+    CHANGES+=("port ${PORT}/${PROTO} opened in zone ${ZONE}")
+    echo "  [OK ] Port ${PORT}/${PROTO} added (permanent)."
+fi
+
+# ── Step 3: Ensure IP forwarding is enabled ───────────────────────────────────
+echo ""
+echo "[STEP 3] Ensure kernel IP forwarding is enabled..."
+CURRENT_FWD=$(cat /proc/sys/net/ipv4/ip_forward 2>/dev/null || echo "0")
+if [[ "${CURRENT_FWD}" == "1" ]]; then
+    echo "  [OK ] IP forwarding already enabled."
+else
+    ${SUDO} sysctl -w net.ipv4.ip_forward=1
+    # Make persistent
+    if ! grep -q 'net.ipv4.ip_forward' /etc/sysctl.d/99-podman.conf 2>/dev/null; then
+        echo "net.ipv4.ip_forward=1" | ${SUDO} tee -a /etc/sysctl.d/99-podman.conf
+    fi
+    CHANGES+=("IP forwarding enabled")
+    echo "  [OK ] IP forwarding enabled and persisted."
+fi
+
+# ── Step 4: Handle RHEL9 nftables / Netavark conflict ────────────────────────
+echo ""
+echo "[STEP 4] Checking for Netavark + firewalld nftables conflict (RHEL9)..."
+OS_VER=$(grep VERSION_ID /etc/os-release | cut -d= -f2 | tr -d '"' | cut -d. -f1)
+if [[ "${OS_VER}" -ge 9 ]] 2>/dev/null; then
+    echo "  [INFO] RHEL9+ detected. Podman uses Netavark (nftables backend)."
+    echo "  [INFO] firewalld also uses nftables on RHEL9."
+    echo ""
+    echo "  Key fix: ensure the 'podman' interface/zone is trusted."
+
+    # Add the podman network interface to the trusted zone
+    PODMAN_IFACE=$(ip link show | grep -E 'podman|cni' | awk -F': ' '{print $2}' | head -1 || true)
+    if [[ -n "${PODMAN_IFACE}" ]]; then
+        echo "  Found Podman interface: ${PODMAN_IFACE}"
+        if ! ${SUDO} firewall-cmd --zone=trusted --query-interface="${PODMAN_IFACE}" 2>/dev/null; then
+            ${SUDO} firewall-cmd --zone=trusted --add-interface="${PODMAN_IFACE}" --permanent
+            CHANGES+=("added ${PODMAN_IFACE} to trusted zone")
+            echo "  [OK ] Added ${PODMAN_IFACE} to trusted zone."
+        else
+            echo "  [OK ] ${PODMAN_IFACE} already in trusted zone."
+        fi
+    else
+        echo "  [INFO] No podman/cni interface found yet (container may not be running)."
+        echo "         After starting your container, re-run this script."
+    fi
+
+    # Add the default Podman subnet to trusted
+    PODMAN_SUBNET="10.88.0.0/16"
+    echo ""
+    echo "  Adding Podman default subnet ${PODMAN_SUBNET} to trusted zone..."
+    if ! ${SUDO} firewall-cmd --zone=trusted --query-source="${PODMAN_SUBNET}" 2>/dev/null; then
+        ${SUDO} firewall-cmd --zone=trusted --add-source="${PODMAN_SUBNET}" --permanent
+        CHANGES+=("Podman subnet ${PODMAN_SUBNET} trusted")
+        echo "  [OK ] Subnet ${PODMAN_SUBNET} added to trusted zone."
+    else
+        echo "  [OK ] Subnet already trusted."
+    fi
+
+    # RHEL9 specific: ensure FORWARD policy allows container traffic
+    echo ""
+    echo "  Ensuring FORWARD chain allows Podman traffic..."
+    if ! ${SUDO} iptables -C FORWARD -i podman0 -j ACCEPT 2>/dev/null && \
+       ! ${SUDO} iptables -C FORWARD -o podman0 -j ACCEPT 2>/dev/null; then
+        echo "  [INFO] Podman FORWARD rules not found — Netavark manages these via nftables."
+        echo "         This is normal on RHEL9+."
+    fi
+fi
+
+# ── Step 5: Reload firewalld ──────────────────────────────────────────────────
+echo ""
+echo "[STEP 5] Reloading firewalld..."
+${SUDO} firewall-cmd --reload
+echo "  [OK ] firewalld reloaded."
+
+# ── Step 6: Restart Podman containers ────────────────────────────────────────
+echo ""
+echo "[STEP 6] Restart any running containers to pick up new firewall rules..."
+echo "  (Podman re-applies port mappings on container restart)"
+RUNNING=$(${SUDO} podman ps --format '{{.Names}}' 2>/dev/null || podman ps --format '{{.Names}}' 2>/dev/null || true)
+if [[ -n "${RUNNING}" ]]; then
+    echo "  Running containers: ${RUNNING}"
+    echo "  [ACTION REQUIRED] Restart your containers manually:"
+    echo "    podman restart <container_name>"
+    echo "  OR re-run: ec2-to-podman/podman_server_setup.sh"
+else
+    echo "  No running containers found. Start your container after this fix."
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "============================================="
+echo " CHANGES APPLIED"
+echo "============================================="
+if [[ ${#CHANGES[@]} -eq 0 ]]; then
+    echo " No changes needed — firewall was already correctly configured."
+    echo " If you still have connectivity issues, check:"
+    echo "   1. AWS Security Group inbound rules for port ${PORT}"
+    echo "   2. SELinux: run diagnostics/check_selinux.sh"
+    echo "   3. Container binding: run ec2-to-podman/check_podman_config.sh"
+else
+    for change in "${CHANGES[@]}"; do
+        echo "  [+] ${change}"
+    done
+fi
+
+echo ""
+echo " Verification commands:"
+echo "   firewall-cmd --zone=${ZONE} --list-all"
+echo "   firewall-cmd --zone=trusted --list-all"
+echo ""
+echo " Next step: re-run the connectivity test:"
+echo "   ec2-to-podman/client_test.sh <RHEL8_IP> ${PORT}  # from RHEL8"
+echo "============================================="

--- a/network-test-scripts/fixes/fix_selinux_podman.sh
+++ b/network-test-scripts/fixes/fix_selinux_podman.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# fix_selinux_podman.sh - Apply SELinux fixes for Podman container networking.
+# Addresses the case where SELinux denies container processes from binding to
+# ports or communicating with external hosts.
+#
+# Run on the RHEL9 EC2 (Podman host) as root / with sudo.
+#
+# Usage: ./fix_selinux_podman.sh [PORT] [MODE]
+#   PORT  Port the container is using (default: 9000)
+#   MODE  'fix' to apply changes, 'diagnose' to only report (default: diagnose)
+
+set -uo pipefail
+
+PORT="${1:-9000}"
+MODE="${2:-diagnose}"
+
+echo "============================================="
+echo " SELINUX PODMAN FIX"
+echo "============================================="
+echo " Port : ${PORT}"
+echo " Mode : ${MODE}"
+echo " Host : $(hostname)"
+echo "============================================="
+echo ""
+
+if [[ "${EUID}" -ne 0 ]]; then
+    SUDO="sudo"
+    echo "[INFO] Running as non-root, using sudo for privileged commands."
+else
+    SUDO=""
+fi
+
+if ! command -v sestatus &>/dev/null; then
+    echo "[INFO] SELinux not installed on this host. No action needed."
+    exit 0
+fi
+
+SEMODE=$(${SUDO} getenforce 2>/dev/null || echo "unknown")
+echo "[INFO] SELinux mode: ${SEMODE}"
+echo ""
+
+apply() {
+    local cmd="$1"
+    local desc="$2"
+    echo "  [ACTION] ${desc}"
+    echo "           Command: ${cmd}"
+    if [[ "${MODE}" == "fix" ]]; then
+        eval "${SUDO} ${cmd}" && echo "  [OK ] Applied." || echo "  [ERROR] Failed to apply."
+    else
+        echo "  [DRY-RUN] Would run: sudo ${cmd}"
+    fi
+    echo ""
+}
+
+# ── Check current denials ─────────────────────────────────────────────────────
+echo "── Recent AVC denials ──────────────────────"
+if command -v ausearch &>/dev/null; then
+    RECENT=$(${SUDO} ausearch -m avc -ts recent 2>/dev/null | grep 'type=AVC' | tail -20)
+    if [[ -n "${RECENT}" ]]; then
+        echo "  [WARN] Active SELinux denials:"
+        echo "${RECENT}" | sed 's/^/  /'
+        echo ""
+
+        # Generate suggested policy
+        echo "  Suggested policy from denials (audit2allow):"
+        echo "${RECENT}" | ${SUDO} audit2allow 2>/dev/null | sed 's/^/  /' || \
+            echo "  (install policycoreutils-python-utils for audit2allow)"
+    else
+        echo "  [OK ] No recent AVC denials."
+    fi
+else
+    echo "  ausearch not available. Checking audit.log directly..."
+    ${SUDO} grep 'type=AVC' /var/log/audit/audit.log 2>/dev/null | tail -20 | sed 's/^/  /' || \
+        echo "  Cannot access audit log."
+fi
+
+echo ""
+
+# ── Port labeling fix ─────────────────────────────────────────────────────────
+echo "── Port SELinux label fix ──────────────────"
+if command -v semanage &>/dev/null; then
+    CURRENT_LABEL=$(${SUDO} semanage port -l 2>/dev/null | grep -E "\b${PORT}\b" || echo "")
+    if [[ -n "${CURRENT_LABEL}" ]]; then
+        echo "  [OK ] Port ${PORT} already has a label: ${CURRENT_LABEL}"
+    else
+        echo "  [WARN] Port ${PORT} has no SELinux label."
+        apply "semanage port -a -t http_port_t -p tcp ${PORT}" \
+            "Label port ${PORT} as http_port_t (allows containers to bind)"
+    fi
+else
+    echo "  semanage not available. Install: dnf install policycoreutils-python-utils"
+fi
+
+echo ""
+
+# ── SELinux booleans for Podman ───────────────────────────────────────────────
+echo "── SELinux Boolean Fixes ───────────────────"
+
+check_and_set_bool() {
+    local bool_name="$1"
+    local reason="$2"
+    local current
+    current=$(${SUDO} getsebool "${bool_name}" 2>/dev/null | awk '{print $NF}' || echo "N/A")
+    printf "  %-40s : %s\n" "${bool_name}" "${current}"
+    if [[ "${current}" != "on" ]]; then
+        echo "    Reason: ${reason}"
+        apply "setsebool -P ${bool_name} on" "Enable ${bool_name}"
+    fi
+}
+
+check_and_set_bool "container_manage_cgroup" \
+    "Allows containers to manage cgroups (required for many container workloads)"
+
+check_and_set_bool "container_connect_any" \
+    "Allows containers to connect to any port (required for external connectivity)"
+
+# ── Generate and apply custom policy from recent denials ─────────────────────
+echo "── Custom SELinux Policy from Denials ──────"
+if command -v audit2allow &>/dev/null && command -v ausearch &>/dev/null; then
+    DENY_CHECK=$(${SUDO} ausearch -m avc -ts recent 2>/dev/null | grep 'type=AVC' | wc -l)
+    if [[ "${DENY_CHECK}" -gt 0 ]]; then
+        POLICY_NAME="podman_netfix"
+        POLICY_TE="/tmp/${POLICY_NAME}.te"
+        POLICY_PP="/tmp/${POLICY_NAME}.pp"
+
+        echo "  Generating custom policy module '${POLICY_NAME}'..."
+        ${SUDO} ausearch -m avc -ts recent 2>/dev/null | \
+            ${SUDO} audit2allow -M "${POLICY_NAME}" 2>/dev/null && \
+            echo "  [OK ] Policy files generated: /tmp/${POLICY_NAME}.{te,pp}" || \
+            echo "  [WARN] Could not generate policy."
+
+        if [[ "${MODE}" == "fix" ]] && [[ -f "/tmp/${POLICY_NAME}.pp" ]]; then
+            echo "  Applying custom policy..."
+            ${SUDO} semodule -i "/tmp/${POLICY_NAME}.pp" && \
+                echo "  [OK ] Custom policy applied." || \
+                echo "  [ERROR] Failed to apply policy."
+        else
+            echo "  [DRY-RUN] Would apply: semodule -i ${POLICY_PP}"
+        fi
+    else
+        echo "  No current denials to build a policy from."
+    fi
+fi
+
+echo ""
+
+# ── Temporary diagnostic mode (permissive for container context) ──────────────
+echo "── Temporary Permissive Mode (container_t) ─"
+echo "  To test if SELinux is blocking container networking:"
+echo "  1. Set container_t domain to permissive:"
+echo "     semanage permissive -a container_t"
+echo "  2. Re-test with nc"
+echo "  3. Check for denials: ausearch -m avc -ts recent | grep container"
+echo "  4. Re-enable:"
+echo "     semanage permissive -d container_t"
+echo ""
+
+if [[ "${MODE}" == "diagnose" ]]; then
+    echo "============================================="
+    echo " DRY-RUN COMPLETE"
+    echo " Re-run with MODE=fix to apply changes:"
+    echo "   ./fix_selinux_podman.sh ${PORT} fix"
+    echo "============================================="
+else
+    echo "============================================="
+    echo " FIXES APPLIED"
+    echo " Verify with: diagnostics/check_selinux.sh ${PORT}"
+    echo " Then retry:  ec2-to-podman/client_test.sh <HOST> ${PORT}"
+    echo "============================================="
+fi

--- a/network-test-scripts/fixes/restart_podman_network.sh
+++ b/network-test-scripts/fixes/restart_podman_network.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# restart_podman_network.sh - Restart Podman networking cleanly to recover
+# from a state where port mappings or firewall rules are broken/stale.
+# Run on the RHEL9 EC2 (Podman host).
+#
+# This script:
+#   1. Stops and removes the test container
+#   2. Resets Podman's network state (if needed)
+#   3. Restarts firewalld
+#   4. Re-launches the container with correct port binding
+#
+# Usage: ./restart_podman_network.sh [CONTAINER_NAME] [HOST_PORT] [CONTAINER_PORT]
+
+set -uo pipefail
+
+CONTAINER="${1:-nc-test-server}"
+HOST_PORT="${2:-9000}"
+CONTAINER_PORT="${3:-9000}"
+
+echo "============================================="
+echo " PODMAN NETWORK RESTART"
+echo "============================================="
+echo " Container     : ${CONTAINER}"
+echo " Host port     : ${HOST_PORT}"
+echo " Container port: ${CONTAINER_PORT}"
+echo " Host          : $(hostname)"
+echo "============================================="
+echo ""
+
+if [[ "${EUID}" -ne 0 ]]; then
+    SUDO="sudo"
+else
+    SUDO=""
+fi
+
+# ── Step 1: Stop the container ────────────────────────────────────────────────
+echo "[STEP 1] Stopping container '${CONTAINER}'..."
+${SUDO} podman stop "${CONTAINER}" 2>/dev/null && echo "  [OK ] Stopped." || echo "  [INFO] Container was not running."
+${SUDO} podman rm "${CONTAINER}" 2>/dev/null && echo "  [OK ] Removed." || echo "  [INFO] Container did not exist."
+
+# Also clean up any stopped containers with the same port
+echo "  Checking for other containers using port ${HOST_PORT}..."
+CONFLICTING=$(${SUDO} podman ps -a --format '{{.Names}} {{.Ports}}' 2>/dev/null | grep ":${HOST_PORT}" | awk '{print $1}' || true)
+if [[ -n "${CONFLICTING}" ]]; then
+    for c in ${CONFLICTING}; do
+        echo "  Removing conflicting container: ${c}"
+        ${SUDO} podman rm -f "${c}" 2>/dev/null || true
+    done
+fi
+
+echo ""
+
+# ── Step 2: Verify no stale process holds the port ────────────────────────────
+echo "[STEP 2] Check for stale processes on port ${HOST_PORT}..."
+STALE=$(${SUDO} ss -tlnp 2>/dev/null | grep ":${HOST_PORT}" || true)
+if [[ -n "${STALE}" ]]; then
+    echo "  [WARN] Something is still listening on port ${HOST_PORT}:"
+    echo "${STALE}" | sed 's/^/    /'
+    PID=$(${SUDO} ss -tlnp 2>/dev/null | grep ":${HOST_PORT}" | grep -oP 'pid=\K[0-9]+' | head -1 || true)
+    if [[ -n "${PID}" ]]; then
+        echo "  PID holding the port: ${PID} ($(${SUDO} ps -p "${PID}" -o comm= 2>/dev/null || echo 'unknown'))"
+        echo "  Kill with: kill ${PID}"
+    fi
+else
+    echo "  [OK ] Port ${HOST_PORT} is free."
+fi
+
+echo ""
+
+# ── Step 3: Reload firewalld ──────────────────────────────────────────────────
+echo "[STEP 3] Reloading firewalld..."
+if systemctl is-active --quiet firewalld 2>/dev/null; then
+    ${SUDO} firewall-cmd --reload && echo "  [OK ] firewalld reloaded." || echo "  [WARN] firewall-cmd reload failed."
+else
+    echo "  [INFO] firewalld not active."
+fi
+
+echo ""
+
+# ── Step 4: Verify IP forwarding ──────────────────────────────────────────────
+echo "[STEP 4] Verify IP forwarding..."
+FWD=$(cat /proc/sys/net/ipv4/ip_forward)
+if [[ "${FWD}" != "1" ]]; then
+    echo "  [WARN] IP forwarding was off. Enabling..."
+    ${SUDO} sysctl -w net.ipv4.ip_forward=1
+    echo "  [OK ] Enabled."
+else
+    echo "  [OK ] IP forwarding is already on."
+fi
+
+echo ""
+
+# ── Step 5: Prune Podman network state ────────────────────────────────────────
+echo "[STEP 5] Pruning stale Podman network resources..."
+${SUDO} podman network prune -f 2>/dev/null && echo "  [OK ] Network prune done." || echo "  [INFO] Network prune skipped."
+
+echo ""
+
+# ── Step 6: Re-run the container server ───────────────────────────────────────
+echo "[STEP 6] Re-launching test container..."
+echo "  Delegating to ec2-to-podman/podman_server_setup.sh ..."
+echo ""
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "${SCRIPT_DIR}/../ec2-to-podman/podman_server_setup.sh" ]]; then
+    bash "${SCRIPT_DIR}/../ec2-to-podman/podman_server_setup.sh" "${HOST_PORT}" "${CONTAINER_PORT}"
+else
+    echo "  [WARN] podman_server_setup.sh not found. Launch the container manually:"
+    echo "    podman run -d --name ${CONTAINER} \\"
+    echo "      -p 0.0.0.0:${HOST_PORT}:${CONTAINER_PORT}/tcp \\"
+    echo "      registry.access.redhat.com/ubi9/ubi-minimal \\"
+    echo "      sh -c 'ncat -lvk -p ${CONTAINER_PORT}'"
+fi
+
+echo ""
+echo "============================================="
+echo " RESTART COMPLETE"
+echo " Test from RHEL8: ec2-to-podman/client_test.sh <RHEL9_IP> ${HOST_PORT}"
+echo "============================================="


### PR DESCRIPTION
Adds a self-contained folder of shell scripts to test and debug TCP
connectivity between two EC2 instances and between an EC2 (RHEL8) and a
Podman container on a second EC2 (RHEL9).

Addresses the specific symptom where tcpdump sees packets arriving but nc
still reports a connection timeout — caused by firewalld, SELinux, or
Podman networking misconfiguration rather than routing/security-group issues.

Scripts included:

ec2-to-ec2/
  server.sh           - nc listener (bind 0.0.0.0) on receiver EC2
  client.sh           - nc connect with payload test from sender
  multi_port_test.sh  - sweep multiple ports and summarise open/closed

ec2-to-podman/
  podman_server_setup.sh  - launch nc listener container with 0.0.0.0 port binding
  client_test.sh          - multi-attempt test from RHEL8 with guided failure output
  check_podman_config.sh  - inspect Netavark/CNI, rootless mode, IP forwarding

diagnostics/
  full_diagnostic.sh   - capture full system state to a timestamped log file
  tcpdump_capture.sh   - capture + auto-interpret SYN/SYN-ACK/RST counts
  check_firewall.sh    - firewalld, iptables, nftables per-port analysis
  check_selinux.sh     - AVC denials, port labels, container booleans
  check_iptables.sh    - Podman/Netavark chains and FORWARD policy

fixes/
  fix_podman_firewall.sh    - masquerade, port open, trusted zone, IP forward
  fix_selinux_podman.sh     - port labels, booleans, audit2allow policy gen
  restart_podman_network.sh - clean container + firewall restart sequence

https://claude.ai/code/session_01M8o3H4J2ggjrMqbMp5cA2S