### PR TITLE
feat(network-test-scripts): port 21240 defaults, custom RHEL8 checks,…

### DIFF
--- a/network-test-scripts/diagnostics/check_conntrack.sh
+++ b/network-test-scripts/diagnostics/check_conntrack.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# check_conntrack.sh - Inspect the kernel connection tracking (conntrack) table.
+#
+# Why this matters for the "tcpdump sees traffic but nc times out" problem:
+#   If the conntrack table is FULL, the kernel silently drops new connection
+#   attempts even though packets arrive at the NIC. tcpdump captures at the
+#   NIC level BEFORE conntrack, so it sees the SYN — but the kernel drops it
+#   immediately without sending a RST or logging it in firewalld.
+#
+#   A conntrack table full of stale Podman NAT entries is a common cause
+#   of intermittent failures when containers are restarted frequently.
+#
+# Run on EITHER host (especially the receiver RHEL8 and the RHEL9 Podman host).
+#
+# Usage: ./check_conntrack.sh [PORT]
+#   PORT  Specific port to search in conntrack table (default: 21240)
+
+set -uo pipefail
+
+PORT="${1:-21240}"
+
+echo "============================================="
+echo " CONNTRACK (Connection Tracking) CHECK"
+echo "============================================="
+echo " Host : $(hostname) / $(hostname -I | awk '{print $1}')"
+echo " Port : ${PORT}"
+echo " Time : $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+echo "============================================="
+echo ""
+
+SUDO=""; [[ "${EUID}" -ne 0 ]] && SUDO="sudo"
+
+# ── Table size vs current usage ───────────────────────────────────────────────
+echo "── Conntrack Table Capacity ────────────────"
+MAX=$(${SUDO} sysctl -n net.netfilter.nf_conntrack_max 2>/dev/null || cat /proc/sys/net/netfilter/nf_conntrack_max 2>/dev/null || echo "unknown")
+CURRENT=$(${SUDO} sysctl -n net.netfilter.nf_conntrack_count 2>/dev/null || cat /proc/sys/net/netfilter/nf_conntrack_count 2>/dev/null || echo "unknown")
+
+echo "  nf_conntrack_max   (max entries) : ${MAX}"
+echo "  nf_conntrack_count (current)     : ${CURRENT}"
+
+if [[ "${MAX}" != "unknown" && "${CURRENT}" != "unknown" ]]; then
+    PCT=$(awk "BEGIN{printf \"%.1f\", (${CURRENT}/${MAX})*100}")
+    echo "  Usage                            : ${PCT}%"
+    if awk "BEGIN{exit (${CURRENT}/${MAX} < 0.80)}"; then
+        echo ""
+        echo "  [WARN] Conntrack table is over 80% full!"
+        echo "  When the table is full, new connections are SILENTLY DROPPED."
+        echo "  tcpdump will see the SYN but nc will never receive it."
+        echo "  Fix: run fixes/fix_conntrack.sh"
+    elif awk "BEGIN{exit (${CURRENT}/${MAX} < 0.50)}"; then
+        echo "  [NOTICE] Table is over 50% full — monitor this."
+    else
+        echo "  [OK ] Table usage is within normal range."
+    fi
+fi
+
+echo ""
+
+# ── Conntrack timeouts (stale entries) ────────────────────────────────────────
+echo "── TCP Conntrack Timeouts ──────────────────"
+echo "  (Long timeouts leave stale entries that consume table space)"
+for key in \
+    net.netfilter.nf_conntrack_tcp_timeout_established \
+    net.netfilter.nf_conntrack_tcp_timeout_time_wait \
+    net.netfilter.nf_conntrack_tcp_timeout_close_wait \
+    net.netfilter.nf_conntrack_tcp_timeout_fin_wait \
+    net.netfilter.nf_conntrack_tcp_timeout_syn_sent \
+    net.netfilter.nf_conntrack_tcp_timeout_syn_recv; do
+    VAL=$(${SUDO} sysctl -n "${key}" 2>/dev/null || echo "N/A")
+    SHORT=$(echo "${key}" | sed 's/net.netfilter.nf_conntrack_tcp_//;s/timeout_//')
+    printf "  %-30s : %s sec\n" "${SHORT}" "${VAL}"
+done
+
+echo ""
+
+# ── Conntrack entries for our port ────────────────────────────────────────────
+echo "── Conntrack Entries for Port ${PORT} ──────"
+if command -v conntrack &>/dev/null || ${SUDO} conntrack --version &>/dev/null 2>&1; then
+    ENTRIES=$(${SUDO} conntrack -L 2>/dev/null | grep -E ":${PORT}\b|dport=${PORT}\b" || true)
+    if [[ -n "${ENTRIES}" ]]; then
+        echo "  Found conntrack entries:"
+        echo "${ENTRIES}" | head -30 | sed 's/^/  /'
+        echo ""
+        echo "  Entry states:"
+        echo "${ENTRIES}" | awk '{for(i=1;i<=NF;i++){if($i~/^[A-Z]+$/){print $i}}}' | sort | uniq -c | sed 's/^/    /'
+    else
+        echo "  No conntrack entries for port ${PORT}."
+        echo "  (Expected if no connections have been attempted yet)"
+    fi
+else
+    echo "  conntrack tool not installed."
+    echo "  Install: dnf install conntrack-tools  (RHEL) or apt install conntrack (Debian)"
+    echo ""
+    echo "  Fallback — reading /proc/net/nf_conntrack directly:"
+    if [[ -f /proc/net/nf_conntrack ]]; then
+        ${SUDO} grep -E "dport=${PORT}|sport=${PORT}" /proc/net/nf_conntrack 2>/dev/null | head -20 | sed 's/^/  /' || \
+            echo "  (no entries or access denied)"
+    fi
+fi
+
+echo ""
+
+# ── INVALID state entries ─────────────────────────────────────────────────────
+echo "── INVALID State Entries (these cause drops) ──"
+if command -v conntrack &>/dev/null || ${SUDO} conntrack --version &>/dev/null 2>&1; then
+    INVALID=$(${SUDO} conntrack -L 2>/dev/null | grep -c INVALID || echo 0)
+    echo "  INVALID conntrack entries: ${INVALID}"
+    if [[ "${INVALID}" -gt 0 ]]; then
+        echo "  [WARN] INVALID entries cause iptables to drop packets."
+        echo "  Common after container restarts that leave stale NAT state."
+        echo "  Fix: ${SUDO} conntrack -D --state INVALID"
+        ${SUDO} conntrack -L 2>/dev/null | grep INVALID | head -10 | sed 's/^/  /'
+    else
+        echo "  [OK ] No INVALID entries."
+    fi
+fi
+
+echo ""
+
+# ── Kernel messages about conntrack ──────────────────────────────────────────
+echo "── Recent Kernel Conntrack Messages ────────"
+${SUDO} dmesg --since "1 hour ago" 2>/dev/null | grep -iE 'nf_conntrack|conntrack|table full' | \
+    tail -20 | sed 's/^/  /' || \
+    ${SUDO} dmesg 2>/dev/null | grep -iE 'nf_conntrack|conntrack|table full' | \
+    tail -20 | sed 's/^/  /' || \
+    echo "  (no conntrack kernel messages or dmesg not accessible)"
+
+echo ""
+
+# ── Podman NAT entries ────────────────────────────────────────────────────────
+echo "── Podman NAT Conntrack Entries ────────────"
+if command -v conntrack &>/dev/null || ${SUDO} conntrack --version &>/dev/null 2>&1; then
+    PODMAN_ENTRIES=$(${SUDO} conntrack -L 2>/dev/null | grep -E '10\.88\.' | wc -l || echo 0)
+    echo "  Entries from Podman subnet (10.88.x.x): ${PODMAN_ENTRIES}"
+    if [[ "${PODMAN_ENTRIES}" -gt 100 ]]; then
+        echo "  [WARN] Large number of Podman NAT entries."
+        echo "  Stale entries after container restart can block new connections."
+        echo "  Fix: ${SUDO} conntrack -F  # flush all (brief connectivity gap)"
+    fi
+fi
+
+echo ""
+echo "============================================="
+echo " SUMMARY"
+echo "============================================="
+if [[ "${MAX}" != "unknown" && "${CURRENT}" != "unknown" ]]; then
+    if awk "BEGIN{exit (${CURRENT}/${MAX} < 0.80)}"; then
+        echo " [ACTION REQUIRED] Conntrack table nearly full — run fixes/fix_conntrack.sh"
+    else
+        echo " [OK] Conntrack table usage is normal."
+        echo " If you still see drops, the issue is likely firewalld or SELinux."
+        echo " Check: diagnostics/check_firewall.sh ${PORT}"
+        echo "        diagnostics/check_selinux.sh ${PORT}"
+    fi
+fi
+echo "============================================="

--- a/network-test-scripts/diagnostics/check_custom_rhel8.sh
+++ b/network-test-scripts/diagnostics/check_custom_rhel8.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# check_custom_rhel8.sh - Checks specific to custom/hardened RHEL8 builds.
+#
+# Custom RHEL8 images (government, enterprise, STIG-hardened, etc.) often add
+# security layers standard RHEL8 does not have. Checks:
+#
+#   1.  fail2ban       - bans IPs after repeated connection failures
+#   2.  Custom iptables chains outside firewalld control
+#   3.  ipset          - IP blocklists via iptables/nftables
+#   4.  rp_filter      - reverse path filtering drops asymmetric/NAT packets
+#   5.  NetworkManager firewall zone (can override firewalld defaults)
+#   6.  Custom sysctl  - tcp_syncookies, somaxconn, ip_forward, etc.
+#   7.  MTU mismatch   - Podman bridge vs host jumbo frames
+#   8.  PAM access.conf - network access control
+#   9.  ip_unprivileged_port_start - rootless Podman bind restriction
+#   10. FIPS mode
+#   11. Loaded netfilter / security kernel modules
+#   12. auditd rules watching network syscalls
+#   13. EDR / security agents (CrowdStrike, Carbon Black, Wazuh, etc.)
+#
+# Run on the RHEL8 receiver EC2.
+#
+# Usage: ./check_custom_rhel8.sh [SENDER_IP] [PORT]
+#   SENDER_IP  IP of RHEL9/Podman host
+#   PORT       Port under test (default: 21240)
+
+set -uo pipefail
+
+SENDER_IP="${1:-}"
+PORT="${2:-21240}"
+
+echo "============================================="
+echo " CUSTOM RHEL8 HARDENING CHECKS"
+echo "============================================="
+echo " Host      : $(hostname)"
+echo " OS        : $(grep PRETTY_NAME /etc/os-release | cut -d= -f2 | tr -d '\"')"
+echo " Kernel    : $(uname -r)"
+echo " Sender IP : ${SENDER_IP:-<not specified>}"
+echo " Port      : ${PORT}"
+echo " Time      : $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+echo "============================================="
+echo ""
+
+SUDO=""; [[ "${EUID}" -ne 0 ]] && SUDO="sudo"
+ISSUES=()
+
+# ── 1. fail2ban ───────────────────────────────────────────────────────────────
+echo "── [1] fail2ban ────────────────────────────"
+if systemctl is-active --quiet fail2ban 2>/dev/null; then
+    echo "  [WARN] fail2ban is RUNNING."
+    echo "  After a few failed nc attempts it may have banned the RHEL9 host IP."
+    echo ""
+    ${SUDO} fail2ban-client status 2>/dev/null | sed 's/^/  /'
+    echo ""
+    if [[ -n "${SENDER_IP}" ]]; then
+        echo "  Checking if ${SENDER_IP} is banned:"
+        for jail in $(${SUDO} fail2ban-client status 2>/dev/null | grep 'Jail list:' | sed 's/.*Jail list://;s/,//g'); do
+            if ${SUDO} fail2ban-client status "${jail}" 2>/dev/null | grep -q "${SENDER_IP}"; then
+                echo "  [CRITICAL] ${SENDER_IP} is BANNED in jail '${jail}'!"
+                echo "  Fix: ${SUDO} fail2ban-client set ${jail} unbanip ${SENDER_IP}"
+                ISSUES+=("fail2ban has banned ${SENDER_IP} in jail ${jail}")
+            else
+                echo "  Jail '${jail}': ${SENDER_IP} not banned."
+            fi
+        done
+    fi
+    echo ""
+    ${SUDO} tail -10 /var/log/fail2ban.log 2>/dev/null | sed 's/^/  /' || true
+else
+    echo "  [OK ] fail2ban is not running."
+fi
+
+echo ""
+
+# ── 2. Custom iptables chains ─────────────────────────────────────────────────
+echo "── [2] Custom iptables chains ──────────────"
+CUSTOM=$(${SUDO} iptables -L -n 2>/dev/null | grep '^Chain ' | \
+    grep -vE 'Chain (INPUT|OUTPUT|FORWARD|POSTROUTING|PREROUTING) ' || true)
+if [[ -n "${CUSTOM}" ]]; then
+    echo "  Custom chains (may contain DROP rules outside firewalld):"
+    echo "${CUSTOM}" | sed 's/^/    /'
+    DROP_RULES=$(${SUDO} iptables -L -n 2>/dev/null | grep -E "DROP|REJECT" | \
+        grep -E ":${PORT}|dpt:${PORT}" || true)
+    if [[ -n "${DROP_RULES}" ]]; then
+        echo "  [CRITICAL] DROP/REJECT rules for port ${PORT}:"
+        echo "${DROP_RULES}" | sed 's/^/    /'
+        ISSUES+=("Custom iptables DROP rule for port ${PORT}")
+    fi
+else
+    echo "  [OK ] No unexpected custom iptables chains."
+fi
+
+echo ""
+
+# ── 3. ipset ──────────────────────────────────────────────────────────────────
+echo "── [3] ipset blocklists ────────────────────"
+if command -v ipset &>/dev/null; then
+    SETS=$(${SUDO} ipset list -n 2>/dev/null || echo "")
+    if [[ -n "${SETS}" ]]; then
+        echo "  ipset sets: ${SETS}"
+        if [[ -n "${SENDER_IP}" ]]; then
+            for set in ${SETS}; do
+                if ${SUDO} ipset test "${set}" "${SENDER_IP}" 2>/dev/null; then
+                    echo "  [WARN] ${SENDER_IP} found in ipset '${set}'"
+                    ISSUES+=("${SENDER_IP} in ipset ${set}")
+                fi
+            done
+        fi
+        IPSET_DROP=$(${SUDO} iptables -L -n 2>/dev/null | grep -i 'match-set' | \
+            grep -E 'DROP|REJECT' || true)
+        if [[ -n "${IPSET_DROP}" ]]; then
+            echo "  [WARN] iptables uses ipsets to DROP traffic:"
+            echo "${IPSET_DROP}" | sed 's/^/    /'
+            ISSUES+=("ipset-based DROP rules in iptables")
+        fi
+    else
+        echo "  [OK ] No ipset sets configured."
+    fi
+else
+    echo "  ipset not installed."
+fi
+
+echo ""
+
+# ── 4. rp_filter ─────────────────────────────────────────────────────────────
+echo "── [4] rp_filter (reverse path filtering) ──"
+echo "  rp_filter=1 drops packets where return route doesn't match source."
+echo "  Podman NAT traffic may arrive with a source IP that fails this check."
+RP_ALL=$(cat /proc/sys/net/ipv4/conf/all/rp_filter 2>/dev/null || echo 0)
+for iface in $(ls /proc/sys/net/ipv4/conf/ 2>/dev/null); do
+    VAL=$(cat "/proc/sys/net/ipv4/conf/${iface}/rp_filter" 2>/dev/null || echo "N/A")
+    [[ "${VAL}" =~ ^[12]$ ]] && printf "  %-20s : %s%s\n" "${iface}" "${VAL}" \
+        "$([[ "${VAL}" == "1" ]] && echo " (strict)" || echo " (loose)")"
+done
+if [[ "${RP_ALL}" == "1" ]]; then
+    echo "  [WARN] rp_filter=1 strict — may drop Podman/NAT traffic."
+    echo "  Fix: sysctl -w net.ipv4.conf.all.rp_filter=2"
+    ISSUES+=("rp_filter=1 strict mode")
+else
+    echo "  [OK ] rp_filter is 0 or loose."
+fi
+
+echo ""
+
+# ── 5. NetworkManager firewall zone ───────────────────────────────────────────
+echo "── [5] NetworkManager firewall zone ────────"
+if command -v nmcli &>/dev/null; then
+    nmcli -f NAME,TYPE,DEVICE,CONNECTION.ZONE con show --active 2>/dev/null | sed 's/^/  /' || \
+        nmcli con show --active 2>/dev/null | sed 's/^/  /'
+    echo "  [INFO] If interface is in 'internal' or 'drop' zone, external traffic is blocked."
+    echo "  Fix:   nmcli con mod <name> connection.zone public && nmcli con up <name>"
+else
+    echo "  nmcli not available."
+fi
+
+echo ""
+
+# ── 6. sysctl hardening ───────────────────────────────────────────────────────
+echo "── [6] Key sysctl values ───────────────────"
+for key in \
+    net.ipv4.ip_forward \
+    net.ipv4.tcp_syncookies \
+    net.ipv4.tcp_max_syn_backlog \
+    net.core.somaxconn \
+    net.ipv4.conf.all.rp_filter \
+    net.ipv4.tcp_fin_timeout; do
+    VAL=$(${SUDO} sysctl -n "${key}" 2>/dev/null || echo "N/A")
+    printf "  %-45s : %s\n" "${key}" "${VAL}"
+    if [[ "${key}" == "net.ipv4.ip_forward" && "${VAL}" == "0" ]]; then
+        echo "    [CRITICAL] ip_forward=0 — container/Podman routing will fail"
+        ISSUES+=("net.ipv4.ip_forward=0")
+    fi
+done
+
+echo ""
+
+# ── 7. MTU mismatch ──────────────────────────────────────────────────────────
+echo "── [7] MTU check ───────────────────────────"
+ip link show 2>/dev/null | awk '/^[0-9]+:/{iface=$2} /mtu/{for(i=1;i<=NF;i++) if($i=="mtu") printf "  %-20s mtu=%s\n", iface, $(i+1)}' | sed 's/:$//'
+PODMAN_MTU=$(ip link show 2>/dev/null | grep -A2 'podman\|cni' | grep -oP 'mtu \K[0-9]+' | head -1 || true)
+ETH_MTU=$(ip route show default 2>/dev/null | awk '{print $5}' | head -1 | xargs -I{} ip link show {} 2>/dev/null | grep -oP 'mtu \K[0-9]+' || echo "1500")
+if [[ -n "${PODMAN_MTU}" && "${PODMAN_MTU}" != "${ETH_MTU}" ]]; then
+    echo "  [WARN] MTU mismatch: host=${ETH_MTU}, Podman bridge=${PODMAN_MTU}"
+    ISSUES+=("MTU mismatch host=${ETH_MTU} vs Podman=${PODMAN_MTU}")
+fi
+
+echo ""
+
+# ── 8. PAM access.conf ────────────────────────────────────────────────────────
+echo "── [8] PAM access control ──────────────────"
+if [[ -f /etc/security/access.conf ]]; then
+    ACTIVE=$(grep -v '^#' /etc/security/access.conf | grep -v '^[[:space:]]*$' || true)
+    [[ -n "${ACTIVE}" ]] && echo "${ACTIVE}" | sed 's/^/  /' || echo "  [OK ] access.conf is empty."
+else
+    echo "  /etc/security/access.conf not found."
+fi
+
+echo ""
+
+# ── 9. ip_unprivileged_port_start ────────────────────────────────────────────
+echo "── [9] ip_unprivileged_port_start ──────────"
+UNPRIV=$(cat /proc/sys/net/ipv4/ip_unprivileged_port_start 2>/dev/null || echo "N/A")
+echo "  ip_unprivileged_port_start: ${UNPRIV}"
+if [[ "${UNPRIV}" != "N/A" ]] && awk "BEGIN{exit (${PORT} >= ${UNPRIV})}"; then
+    echo "  [WARN] Port ${PORT} < ip_unprivileged_port_start (${UNPRIV})"
+    echo "         Rootless Podman containers cannot bind port ${PORT}."
+    echo "  Fix:   sysctl -w net.ipv4.ip_unprivileged_port_start=1024"
+    ISSUES+=("Port ${PORT} blocked for rootless Podman (ip_unprivileged_port_start=${UNPRIV})")
+else
+    echo "  [OK ] Port ${PORT} is in unprivileged range."
+fi
+
+echo ""
+
+# ── 10. FIPS mode ────────────────────────────────────────────────────────────
+echo "── [10] FIPS mode ──────────────────────────"
+FIPS=$(cat /proc/sys/crypto/fips_enabled 2>/dev/null || echo "0")
+echo "  FIPS enabled: ${FIPS}"
+[[ "${FIPS}" == "1" ]] && echo "  [INFO] FIPS mode on. Custom security wrappers may enforce cipher requirements."
+
+echo ""
+
+# ── 11. Netfilter kernel modules ─────────────────────────────────────────────
+echo "── [11] Loaded netfilter / security modules ──"
+${SUDO} lsmod 2>/dev/null | grep -E '^(nf_|xt_|ipt_|ebt_|ip6t_)' | \
+    awk '{printf "  %-35s used=%s\n", $1, $3}' | head -20 || echo "  (lsmod unavailable)"
+
+echo ""
+
+# ── 12. auditd network syscall rules ─────────────────────────────────────────
+echo "── [12] auditd network syscall rules ───────"
+if command -v auditctl &>/dev/null; then
+    ${SUDO} auditctl -l 2>/dev/null | grep -E 'connect|bind|accept|socket' | \
+        sed 's/^/  /' || echo "  No network syscall audit rules."
+else
+    echo "  auditctl not available."
+fi
+
+echo ""
+
+# ── 13. EDR / security agents ────────────────────────────────────────────────
+echo "── [13] Security agents / EDR ─────────────"
+declare -A AGENTS=(
+    ["falcon-sensor"]="CrowdStrike Falcon"
+    ["cbdaemon"]="Carbon Black"
+    ["ds_agent"]="Trend Micro"
+    ["clamd"]="ClamAV"
+    ["wazuh-agentd"]="Wazuh HIDS"
+    ["ossec"]="OSSEC HIDS"
+    ["fireeye"]="FireEye"
+    ["cylancesvc"]="Cylance"
+    ["sentineld"]="SentinelOne"
+)
+FOUND=false
+for proc in "${!AGENTS[@]}"; do
+    if pgrep -x "${proc}" &>/dev/null 2>&1 || systemctl is-active --quiet "${proc}" 2>/dev/null; then
+        echo "  [INFO] ${AGENTS[$proc]} (${proc}) is running — may intercept connections."
+        ISSUES+=("EDR agent: ${AGENTS[$proc]}")
+        FOUND=true
+    fi
+done
+[[ "${FOUND}" == "false" ]] && echo "  [OK ] No known EDR agents detected."
+
+echo ""
+echo "============================================="
+echo " SUMMARY — ${#ISSUES[@]} issue(s) found"
+echo "============================================="
+if [[ ${#ISSUES[@]} -eq 0 ]]; then
+    echo " [OK] No custom RHEL8 hardening issues found."
+    echo " Next: diagnostics/check_tcp_wrappers.sh ${SENDER_IP:-<RHEL9_IP>}"
+    echo "       diagnostics/check_conntrack.sh ${PORT}"
+else
+    for issue in "${ISSUES[@]}"; do echo "  [!] ${issue}"; done
+fi
+echo "============================================="

--- a/network-test-scripts/diagnostics/check_debian_pod.sh
+++ b/network-test-scripts/diagnostics/check_debian_pod.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# check_debian_pod.sh - Inspect the Debian developer pod from inside via
+# podman exec. Checks ufw, internal iptables, nc flavour, listening ports,
+# and runs an outbound connectivity test from inside the container.
+#
+# Run on the RHEL9 EC2 that hosts the Podman container.
+#
+# Usage: ./check_debian_pod.sh [CONTAINER_NAME] [PORT] [TARGET_RHEL8_IP]
+#   CONTAINER_NAME   Name or ID of the Debian container (default: dev-pod)
+#   PORT             Port under test (default: 21240)
+#   TARGET_RHEL8_IP  IP of the RHEL8 EC2 for outbound test
+
+set -uo pipefail
+
+CONTAINER="${1:-dev-pod}"
+PORT="${2:-21240}"
+RHEL8_IP="${3:-}"
+
+echo "============================================="
+echo " DEBIAN DEVELOPER POD DIAGNOSTIC"
+echo "============================================="
+echo " Container    : ${CONTAINER}"
+echo " Port         : ${PORT}"
+echo " Target RHEL8 : ${RHEL8_IP:-<not specified>}"
+echo " RHEL9 Host   : $(hostname)"
+echo " Podman ver   : $(podman --version)"
+echo "============================================="
+echo ""
+
+SUDO=""; [[ "${EUID}" -ne 0 ]] && SUDO="sudo"
+
+# ── Is the container running? ─────────────────────────────────────────────────
+echo "── Container Status ────────────────────────"
+CONTAINER_ID=$(${SUDO} podman ps --filter "name=${CONTAINER}" --format "{{.ID}}" 2>/dev/null || \
+               podman ps --filter "name=${CONTAINER}" --format "{{.ID}}" 2>/dev/null || true)
+
+if [[ -z "${CONTAINER_ID}" ]]; then
+    echo "  [ERROR] Container '${CONTAINER}' is not running."
+    echo "  Running containers:"
+    ${SUDO} podman ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null | sed 's/^/    /'
+    exit 1
+fi
+echo "  [OK ] Container '${CONTAINER}' running (ID: ${CONTAINER_ID:0:12})"
+
+EXEC="${SUDO} podman exec ${CONTAINER}"
+
+echo ""
+
+# ── Network inside container ──────────────────────────────────────────────────
+echo "── Container Network ───────────────────────"
+${EXEC} ip addr show 2>/dev/null | sed 's/^/  /' || \
+    ${EXEC} ifconfig 2>/dev/null | sed 's/^/  /' || \
+    echo "  (ip/ifconfig not available)"
+
+echo ""
+echo "── Container Default Route ─────────────────"
+${EXEC} ip route show 2>/dev/null | sed 's/^/  /' || \
+    ${EXEC} route -n 2>/dev/null | sed 's/^/  /'
+echo "  [INFO] Gateway should be the Podman bridge (e.g. 10.88.0.1)"
+
+echo ""
+
+# ── ufw ───────────────────────────────────────────────────────────────────────
+echo "── ufw (Uncomplicated Firewall) ────────────"
+if ${EXEC} which ufw &>/dev/null 2>&1; then
+    UFW_STATUS=$(${EXEC} ufw status 2>/dev/null || echo "unknown")
+    echo "  ${UFW_STATUS}"
+    if echo "${UFW_STATUS}" | grep -qi "active"; then
+        echo "  [WARN] ufw is ACTIVE inside the container."
+        echo "  Fix:   podman exec ${CONTAINER} ufw allow out ${PORT}/tcp"
+        echo "         OR: podman exec ${CONTAINER} ufw disable"
+    else
+        echo "  [OK ] ufw inactive."
+    fi
+else
+    echo "  ufw not found in container."
+fi
+
+echo ""
+
+# ── iptables inside container ─────────────────────────────────────────────────
+echo "── iptables inside container ────────────────"
+CT_IPTA=$(${EXEC} iptables -L -n 2>/dev/null || true)
+if [[ -n "${CT_IPTA}" ]]; then
+    echo "${CT_IPTA}" | head -40 | sed 's/^/  /'
+    if echo "${CT_IPTA}" | grep -q "DROP\|REJECT"; then
+        echo "  [WARN] DROP/REJECT rules inside the container!"
+    fi
+else
+    echo "  iptables empty or unavailable (normal for rootless containers)."
+fi
+
+echo ""
+
+# ── nc flavour inside container ───────────────────────────────────────────────
+echo "── nc inside container ─────────────────────"
+echo "  [INFO] Debian uses netcat-openbsd by default — flags differ from ncat."
+echo "         openbsd nc: -l (listen), no -p flag, use -l PORT directly"
+echo "         ncat:       -l -p PORT"
+for cmd in nc ncat netcat socat; do
+    if ${EXEC} which "${cmd}" &>/dev/null 2>&1; then
+        echo "  Found: ${cmd} → $(${EXEC} which ${cmd} 2>/dev/null)"
+        NC_VER=$(${EXEC} ${cmd} --version 2>&1 | head -1 || ${EXEC} ${cmd} -h 2>&1 | head -1 || true)
+        echo "    ${NC_VER}"
+    fi
+done
+
+echo ""
+
+# ── Listening ports inside container ─────────────────────────────────────────
+echo "── Listening ports inside container ─────────"
+${EXEC} ss -tlnp 2>/dev/null | sed 's/^/  /' || \
+    ${EXEC} netstat -tlnp 2>/dev/null | sed 's/^/  /' || \
+    echo "  (ss/netstat not available)"
+echo ""
+echo "  Port ${PORT} specifically:"
+${EXEC} ss -tlnp 2>/dev/null | grep ":${PORT}" | sed 's/^/    /' || \
+    echo "    Not listening on ${PORT} inside container."
+
+echo ""
+
+# ── Outbound test from inside container ──────────────────────────────────────
+echo "── Outbound connectivity from container ─────"
+if [[ -n "${RHEL8_IP}" ]]; then
+    echo "  Testing nc from container → RHEL8 (${RHEL8_IP}:${PORT})..."
+    if ${EXEC} sh -c "nc -z -w 5 ${RHEL8_IP} ${PORT}" 2>/dev/null; then
+        echo "  [OK ] Container can reach RHEL8:${PORT}"
+    else
+        echo "  [FAIL] Container cannot reach ${RHEL8_IP}:${PORT}"
+        ${EXEC} ping -c 2 -W 2 "${RHEL8_IP}" 2>/dev/null | tail -3 | sed 's/^/    /' || \
+            echo "    (ping unavailable)"
+    fi
+    echo ""
+    echo "  Testing internet reachability (8.8.8.8:53):"
+    ${EXEC} nc -z -w 3 8.8.8.8 53 2>/dev/null && \
+        echo "  [OK ] Container can reach internet." || \
+        echo "  [FAIL] Container cannot reach internet — possible network isolation."
+else
+    echo "  Specify TARGET_RHEL8_IP as 3rd argument to run outbound tests."
+fi
+
+echo ""
+
+# ── Podman port bindings and network mode ─────────────────────────────────────
+echo "── Podman port bindings ─────────────────────"
+${SUDO} podman port "${CONTAINER}" 2>/dev/null | sed 's/^/  /' || \
+    podman port "${CONTAINER}" 2>/dev/null | sed 's/^/  /' || \
+    echo "  (no published ports)"
+
+echo ""
+${SUDO} podman inspect "${CONTAINER}" 2>/dev/null | python3 -c "
+import json, sys
+d = json.load(sys.stdin)[0]
+ns = d.get('NetworkSettings', {})
+print(f\"  IP      : {ns.get('IPAddress', 'N/A')}\")
+print(f\"  Gateway : {ns.get('Gateway', 'N/A')}\")
+hc = d.get('HostConfig', {})
+print(f\"  NetMode : {hc.get('NetworkMode', 'N/A')}\")
+pb = hc.get('PortBindings', {})
+for k, v in (pb or {}).items():
+    for b in (v or []):
+        print(f\"  Port    : {k} -> {b.get('HostIp','0.0.0.0')}:{b.get('HostPort','?')}\")
+" 2>/dev/null | sed 's/^/  /' || true
+
+echo ""
+
+# ── Container logs ────────────────────────────────────────────────────────────
+echo "── Recent container logs (last 20) ─────────"
+${SUDO} podman logs --tail 20 "${CONTAINER}" 2>&1 | sed 's/^/  /' || \
+    podman logs --tail 20 "${CONTAINER}" 2>&1 | sed 's/^/  /'
+
+echo ""
+echo "============================================="
+echo " If container cannot reach RHEL8:${PORT}:"
+echo "  1. Check ufw/iptables above"
+echo "  2. Check RHEL8 firewall: check_firewall.sh ${PORT}"
+echo "  3. Check RHEL8 custom layers: check_custom_rhel8.sh ${RHEL8_IP:-<IP>} ${PORT}"
+echo "  4. Re-launch with correct nc syntax for Debian:"
+echo "     podman exec ${CONTAINER} nc -l ${PORT}   # openbsd nc"
+echo "     podman exec ${CONTAINER} ncat -lvk -p ${PORT}   # ncat"
+echo "============================================="

--- a/network-test-scripts/diagnostics/check_firewall.sh
+++ b/network-test-scripts/diagnostics/check_firewall.sh
@@ -4,12 +4,12 @@
 # Run on EITHER host.
 #
 # Usage: ./check_firewall.sh [PORT] [PROTOCOL]
-#   PORT      Port to check (default: 9000)
+#   PORT      Port to check (default: 21240)
 #   PROTOCOL  tcp or udp (default: tcp)
 
 set -uo pipefail
 
-PORT="${1:-9000}"
+PORT="${1:-21240}"
 PROTO="${2:-tcp}"
 
 echo "============================================="

--- a/network-test-scripts/diagnostics/check_iptables.sh
+++ b/network-test-scripts/diagnostics/check_iptables.sh
@@ -7,7 +7,7 @@
 
 set -uo pipefail
 
-PORT="${1:-9000}"
+PORT="${1:-21240}"
 
 echo "============================================="
 echo " IPTABLES / NFTABLES DEEP INSPECTION"

--- a/network-test-scripts/diagnostics/check_selinux.sh
+++ b/network-test-scripts/diagnostics/check_selinux.sh
@@ -4,11 +4,11 @@
 # Run on the RHEL8 or RHEL9 host.
 #
 # Usage: ./check_selinux.sh [PORT]
-#   PORT  Specific port to check labeling for (optional, default: 9000)
+#   PORT  Specific port to check labeling for (optional, default: 21240)
 
 set -uo pipefail
 
-PORT="${1:-9000}"
+PORT="${1:-21240}"
 
 echo "============================================="
 echo " SELINUX NETWORK & PODMAN CHECK"

--- a/network-test-scripts/diagnostics/check_tcp_wrappers.sh
+++ b/network-test-scripts/diagnostics/check_tcp_wrappers.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# check_tcp_wrappers.sh - Check TCP Wrappers (hosts.allow / hosts.deny).
+#
+# TCP Wrappers is a legacy access control layer that operates INDEPENDENTLY
+# of firewalld and iptables. On custom RHEL8 builds it is sometimes still
+# active and can silently reject connections that pass the firewall.
+#
+# How it works:
+#   1. /etc/hosts.allow is checked first  → if matched, connection is ALLOWED
+#   2. /etc/hosts.deny  is checked second → if matched, connection is DENIED
+#   3. If neither file matches            → connection is ALLOWED (default)
+#
+# A deny rule drops the connection silently — tcpdump sees the SYN arriving
+# but nc on the receiver never gets it. The sender eventually times out.
+#
+# Run on the RHEL8 receiver EC2.
+#
+# Usage: ./check_tcp_wrappers.sh [SENDER_IP]
+#   SENDER_IP  IP of the RHEL9 Podman host — used to check if it would be denied
+
+set -uo pipefail
+
+SENDER_IP="${1:-}"
+
+echo "============================================="
+echo " TCP WRAPPERS CHECK (hosts.allow / hosts.deny)"
+echo "============================================="
+echo " Host      : $(hostname)"
+echo " Sender IP : ${SENDER_IP:-<not specified>}"
+echo "============================================="
+echo ""
+
+# ── Is TCP Wrappers active? ───────────────────────────────────────────────────
+echo "── Is TCP Wrappers in use? ─────────────────"
+
+WRAPPED=false
+
+for daemon in sshd nc ncat in.telnetd xinetd vsftpd; do
+    if command -v "${daemon}" &>/dev/null; then
+        if ldd "$(which ${daemon} 2>/dev/null)" 2>/dev/null | grep -q libwrap; then
+            echo "  [WARN] ${daemon} is linked with libwrap — TCP Wrappers IS active for it."
+            WRAPPED=true
+        fi
+    fi
+done
+
+if systemctl is-active --quiet xinetd 2>/dev/null; then
+    echo "  [WARN] xinetd is running — services it manages use TCP Wrappers."
+    WRAPPED=true
+fi
+
+if rpm -q tcp_wrappers 2>/dev/null | grep -qv 'not installed'; then
+    echo "  [INFO] tcp_wrappers RPM is installed."
+    WRAPPED=true
+fi
+
+if [[ "${WRAPPED}" == "false" ]]; then
+    echo "  [OK ] No evidence TCP Wrappers is active for nc/ncat."
+else
+    echo ""
+    echo "  [ACTION] TCP Wrappers is active — review hosts.allow/deny below."
+fi
+
+echo ""
+
+# ── /etc/hosts.allow ─────────────────────────────────────────────────────────
+echo "── /etc/hosts.allow ────────────────────────"
+if [[ -f /etc/hosts.allow ]]; then
+    cat -n /etc/hosts.allow | sed 's/^/  /'
+else
+    echo "  /etc/hosts.allow not found."
+fi
+
+echo ""
+
+# ── /etc/hosts.deny ──────────────────────────────────────────────────────────
+echo "── /etc/hosts.deny ─────────────────────────"
+if [[ -f /etc/hosts.deny ]]; then
+    cat -n /etc/hosts.deny | sed 's/^/  /'
+
+    if grep -q 'ALL[[:space:]]*:[[:space:]]*ALL' /etc/hosts.deny; then
+        echo ""
+        echo "  [CRITICAL] hosts.deny contains 'ALL:ALL' — denies EVERYTHING"
+        echo "  not explicitly allowed in hosts.allow."
+        echo "  Fix: add to /etc/hosts.allow:"
+        echo "    ALL: ${SENDER_IP:-<RHEL9_IP>}"
+        echo "    OR: ALL: 10.0.0.0/8  (entire VPC CIDR)"
+    fi
+else
+    echo "  /etc/hosts.deny not found."
+fi
+
+echo ""
+
+# ── Sender IP check ───────────────────────────────────────────────────────────
+if [[ -n "${SENDER_IP}" ]]; then
+    echo "── Sender IP ${SENDER_IP} access check ───────"
+    if command -v tcpdmatch &>/dev/null; then
+        echo "  tcpdmatch result:"
+        tcpdmatch ALL "${SENDER_IP}" 2>/dev/null | sed 's/^/  /'
+    else
+        echo "  tcpdmatch not available — manual check:"
+        if [[ -f /etc/hosts.allow ]]; then
+            grep -n -E "ALL|${SENDER_IP}" /etc/hosts.allow | grep -v '^#' | sed 's/^/    ALLOW match: /' || true
+        fi
+        if [[ -f /etc/hosts.deny ]]; then
+            grep -n -E "ALL|${SENDER_IP}" /etc/hosts.deny | grep -v '^#' | sed 's/^/    DENY  match: /' || true
+        fi
+    fi
+fi
+
+echo ""
+echo "── Fix: Allow RHEL9 traffic ────────────────"
+echo "  Add to /etc/hosts.allow (takes effect immediately, no restart):"
+echo ""
+if [[ -n "${SENDER_IP}" ]]; then
+    echo "    ALL: ${SENDER_IP}"
+else
+    echo "    ALL: <RHEL9_HOST_IP>"
+fi
+echo "    ALL: 10.0.0.0/255.0.0.0    # entire VPC private range"
+echo "============================================="

--- a/network-test-scripts/diagnostics/full_diagnostic.sh
+++ b/network-test-scripts/diagnostics/full_diagnostic.sh
@@ -4,14 +4,14 @@
 #
 # Usage: ./full_diagnostic.sh [TARGET_IP] [PORT]
 #   TARGET_IP  Remote host IP to include in connectivity checks (optional)
-#   PORT       Port to check specifically (optional, default: 9000)
+#   PORT       Port to check specifically (optional, default: 21240)
 #
 # Output is written to a timestamped log file for easy sharing.
 
 set -uo pipefail
 
 TARGET_IP="${1:-}"
-PORT="${2:-9000}"
+PORT="${2:-21240}"
 LOGFILE="/tmp/network_diag_$(hostname -s)_$(date +%Y%m%d_%H%M%S).log"
 
 run_section() {

--- a/network-test-scripts/diagnostics/tcpdump_capture.sh
+++ b/network-test-scripts/diagnostics/tcpdump_capture.sh
@@ -10,7 +10,7 @@
 # Run this on EITHER host while running the nc test from the other side.
 #
 # Usage: ./tcpdump_capture.sh [PORT] [INTERFACE] [DURATION_SECS]
-#   PORT       Port to capture (default: 9000)
+#   PORT       Port to capture (default: 21240)
 #   INTERFACE  Network interface (default: auto-detected)
 #   DURATION   How long to capture in seconds (default: 30)
 #
@@ -18,7 +18,7 @@
 
 set -uo pipefail
 
-PORT="${1:-9000}"
+PORT="${1:-21240}"
 IFACE="${2:-}"
 DURATION="${3:-30}"
 CAPFILE="/tmp/capture_port${PORT}_$(date +%Y%m%d_%H%M%S).pcap"

--- a/network-test-scripts/ec2-to-ec2/alt_connect_test.sh
+++ b/network-test-scripts/ec2-to-ec2/alt_connect_test.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# alt_connect_test.sh - Test connectivity using every available tool, not just nc.
+#
+# When nc shows a timeout, this script tries alternative tools to isolate
+# whether the problem is with nc specifically or the network path itself.
+#
+# Tools tried:
+#   1. nc / ncat      - standard baseline
+#   2. bash /dev/tcp  - bash built-in (no external binary — pure kernel socket)
+#   3. socat          - different socket options than nc
+#   4. curl           - HTTP TCP connect (reveals port vs application issue)
+#   5. telnet         - different syscall path
+#   6. python3 socket - raw socket, different SELinux context from nc
+#   7. nmap -sT       - 'filtered' vs 'closed' tells you if firewall is dropping
+#   8. openssl        - TCP + optional TLS
+#
+# KEY DIAGNOSTIC VALUE:
+#   If /dev/tcp SUCCEEDS but nc FAILS → problem is nc-specific, not the network.
+#   If nmap says FILTERED → firewall is silently dropping (no RST).
+#   If nmap says CLOSED   → port is reachable but nothing is listening.
+#
+# Usage: ./alt_connect_test.sh <HOST> [PORT] [TIMEOUT_SECS]
+
+set -uo pipefail
+
+HOST="${1:-}"
+PORT="${2:-21240}"
+TIMEOUT="${3:-5}"
+
+if [[ -z "${HOST}" ]]; then
+    echo "Usage: $0 <HOST> [PORT] [TIMEOUT_SECS]"
+    exit 1
+fi
+
+echo "============================================="
+echo " ALTERNATIVE CONNECTIVITY TESTS"
+echo "============================================="
+echo " Target  : ${HOST}:${PORT}"
+echo " Timeout : ${TIMEOUT}s per test"
+echo " From    : $(hostname) ($(hostname -I | awk '{print $1}'))"
+echo " Time    : $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+echo "============================================="
+echo ""
+
+PASS=()
+FAIL=()
+SKIP=()
+
+result() {
+    local name="$1" rc="$2"
+    printf "  [%-20s] " "${name}"
+    if [[ "${rc}" -eq 0 ]]; then echo "SUCCESS"; PASS+=("${name}")
+    else echo "FAILED"; FAIL+=("${name}"); fi
+}
+
+echo "── 1. nc / ncat ────────────────────────────"
+if command -v nc &>/dev/null; then
+    nc -z -w "${TIMEOUT}" "${HOST}" "${PORT}" 2>/dev/null; result "nc -z" $?
+else
+    echo "  [nc                   ] SKIP"; SKIP+=("nc")
+fi
+if command -v ncat &>/dev/null; then
+    ncat -z -w "${TIMEOUT}" "${HOST}" "${PORT}" 2>/dev/null; result "ncat" $?
+fi
+
+echo ""
+echo "── 2. bash /dev/tcp (no binary) ────────────"
+echo "  Pure kernel socket — bypasses nc entirely."
+timeout "${TIMEOUT}" bash -c "exec 3<>/dev/tcp/${HOST}/${PORT}" 2>/dev/null
+RC=$?; exec 3>&- 2>/dev/null || true; result "/dev/tcp" "${RC}"
+if [[ "${RC}" -eq 0 ]]; then
+    echo "  [KEY] /dev/tcp succeeded — if nc fails, issue is nc-specific."
+fi
+
+echo ""
+echo "── 3. socat ────────────────────────────────"
+if command -v socat &>/dev/null; then
+    timeout "${TIMEOUT}" socat /dev/null "TCP:${HOST}:${PORT},connect-timeout=${TIMEOUT}" 2>/dev/null
+    result "socat" $?
+else
+    echo "  [socat                ] SKIP — dnf install socat"; SKIP+=("socat")
+fi
+
+echo ""
+echo "── 4. curl --connect-only ──────────────────"
+if command -v curl &>/dev/null; then
+    COUT=$(curl --connect-only --max-time "${TIMEOUT}" "http://${HOST}:${PORT}" 2>&1)
+    CRC=$?
+    if [[ "${CRC}" -eq 0 ]] || echo "${COUT}" | grep -qE "52|Empty reply"; then
+        echo "  [curl --connect-only  ] TCP CONNECTED (HTTP layer varies)"; PASS+=("curl")
+    elif echo "${COUT}" | grep -q "refused"; then
+        echo "  [curl --connect-only  ] PORT CLOSED (RST received)"; FAIL+=("curl")
+    else
+        echo "  [curl --connect-only  ] FAILED/TIMEOUT"; FAIL+=("curl")
+    fi
+else
+    echo "  [curl                 ] SKIP"; SKIP+=("curl")
+fi
+
+echo ""
+echo "── 5. telnet ───────────────────────────────"
+if command -v telnet &>/dev/null; then
+    TOUT=$(echo "quit" | timeout "${TIMEOUT}" telnet "${HOST}" "${PORT}" 2>&1 || true)
+    if echo "${TOUT}" | grep -qE "Connected|Escape"; then
+        echo "  [telnet               ] CONNECTED"; PASS+=("telnet")
+    elif echo "${TOUT}" | grep -q "refused"; then
+        echo "  [telnet               ] REFUSED (port closed)"; FAIL+=("telnet-refused")
+    else
+        echo "  [telnet               ] FAILED/TIMEOUT"; FAIL+=("telnet")
+    fi
+else
+    echo "  [telnet               ] SKIP — dnf install telnet"; SKIP+=("telnet")
+fi
+
+echo ""
+echo "── 6. python3 raw socket ───────────────────"
+if command -v python3 &>/dev/null; then
+    timeout "${TIMEOUT}" python3 - <<PYEOF 2>/dev/null
+import socket, sys
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.settimeout(${TIMEOUT})
+try:
+    s.connect(('${HOST}', ${PORT}))
+    s.close()
+    sys.exit(0)
+except Exception as e:
+    sys.exit(1)
+PYEOF
+    result "python3 socket" $?
+else
+    echo "  [python3 socket       ] SKIP"; SKIP+=("python3")
+fi
+
+echo ""
+echo "── 7. nmap SYN scan ────────────────────────"
+if command -v nmap &>/dev/null; then
+    NOUT=$(nmap -sT -p "${PORT}" --host-timeout "${TIMEOUT}s" "${HOST}" 2>/dev/null | grep -E "${PORT}|open|closed|filtered")
+    echo "  ${NOUT}"
+    if echo "${NOUT}" | grep -q "open"; then
+        echo "  [nmap                 ] OPEN"; PASS+=("nmap")
+    elif echo "${NOUT}" | grep -q "filtered"; then
+        echo "  [nmap                 ] FILTERED — firewall is silently dropping (no RST)"
+        echo "  [KEY] 'filtered' = DROP rule. 'closed' = RST = port is reachable."
+        FAIL+=("nmap-filtered")
+    else
+        echo "  [nmap                 ] CLOSED"; FAIL+=("nmap-closed")
+    fi
+else
+    echo "  [nmap                 ] SKIP — dnf install nmap"; SKIP+=("nmap")
+fi
+
+echo ""
+echo "── 8. openssl s_client ─────────────────────"
+if command -v openssl &>/dev/null; then
+    OOUT=$(echo "Q" | timeout "${TIMEOUT}" openssl s_client -connect "${HOST}:${PORT}" 2>&1 | head -3 || true)
+    if echo "${OOUT}" | grep -qE "CONNECTED|BEGIN CERT"; then
+        echo "  [openssl              ] TCP+TLS CONNECTED"; PASS+=("openssl")
+    elif echo "${OOUT}" | grep -qE "errno|no peer cert|handshake"; then
+        echo "  [openssl              ] TCP connected, no TLS (expected for plain nc)"; PASS+=("openssl-tcp")
+    else
+        echo "  [openssl              ] FAILED"; FAIL+=("openssl")
+    fi
+else
+    echo "  [openssl              ] SKIP"; SKIP+=("openssl")
+fi
+
+echo ""
+echo "============================================="
+echo " SUMMARY"
+echo "============================================="
+echo " PASS (${#PASS[@]}): ${PASS[*]:-none}"
+echo " FAIL (${#FAIL[@]}): ${FAIL[*]:-none}"
+echo " SKIP (${#SKIP[@]}): ${SKIP[*]:-none}"
+echo ""
+
+if [[ ${#PASS[@]} -gt 0 && ${#FAIL[@]} -gt 0 ]]; then
+    echo " [FINDING] Mixed results — issue is tool-specific, not the network path."
+    if [[ " ${PASS[*]} " =~ "/dev/tcp" ]] && printf '%s\n' "${FAIL[@]}" | grep -q "^nc"; then
+        echo "  → /dev/tcp works but nc fails: SELinux label or nc socket option blocked."
+    fi
+elif [[ ${#PASS[@]} -eq 0 ]] && [[ ${#SKIP[@]} -lt 4 ]]; then
+    echo " [FINDING] All tools failed — issue is in the network path."
+    echo " Check: diagnostics/check_firewall.sh ${PORT} (on ${HOST})"
+    echo "         diagnostics/check_custom_rhel8.sh (on ${HOST})"
+    echo "         AWS Security Group inbound rules for port ${PORT}"
+else
+    echo " [OK] ${HOST}:${PORT} is reachable from this host."
+fi
+echo "============================================="

--- a/network-test-scripts/ec2-to-ec2/client.sh
+++ b/network-test-scripts/ec2-to-ec2/client.sh
@@ -8,8 +8,8 @@
 #   TIMEOUT_SECS  Connection timeout in seconds (default: 5)
 #
 # Example:
-#   ./client.sh 10.0.1.50 9000
-#   ./client.sh 10.0.1.50 9000 10
+#   ./client.sh 10.0.1.50 21240
+#   ./client.sh 10.0.1.50 21240 10
 
 set -euo pipefail
 

--- a/network-test-scripts/ec2-to-ec2/multi_port_test.sh
+++ b/network-test-scripts/ec2-to-ec2/multi_port_test.sh
@@ -5,7 +5,7 @@
 #
 # Usage: ./multi_port_test.sh <HOST> [PORT_LIST] [TIMEOUT_SECS]
 #   HOST        Target IP or hostname
-#   PORT_LIST   Comma-separated ports (default: 80,443,8080,8443,9000,9090,5000,6000)
+#   PORT_LIST   Comma-separated ports (default: 21240,80,443,8080,8443,9000,9090,5000,6000)
 #   TIMEOUT     Per-port timeout in seconds (default: 3)
 #
 # Example:
@@ -16,7 +16,7 @@
 set -euo pipefail
 
 HOST="${1:-}"
-PORT_LIST="${2:-80,443,8080,8443,9000,9090,5000,6000}"
+PORT_LIST="${2:-21240,80,443,8080,8443,9000,9090,5000,6000}"
 TIMEOUT="${3:-3}"
 
 if [[ -z "${HOST}" ]]; then

--- a/network-test-scripts/ec2-to-ec2/server.sh
+++ b/network-test-scripts/ec2-to-ec2/server.sh
@@ -7,8 +7,8 @@
 #   BIND_ADDR   Address to bind to (default: 0.0.0.0 = all interfaces)
 #
 # Example:
-#   ./server.sh 9000
-#   ./server.sh 9000 0.0.0.0
+#   ./server.sh 21240
+#   ./server.sh 21240 0.0.0.0
 
 set -euo pipefail
 

--- a/network-test-scripts/ec2-to-podman/client_test.sh
+++ b/network-test-scripts/ec2-to-podman/client_test.sh
@@ -6,16 +6,16 @@
 #
 # Usage: ./client_test.sh <RHEL9_HOST_IP> [PORT] [TIMEOUT_SECS]
 #   RHEL9_HOST_IP  Public or private IP of the RHEL9 EC2
-#   PORT           Port published from the Podman container (default: 9000)
+#   PORT           Port published from the Podman container (default: 21240)
 #   TIMEOUT        Connection timeout (default: 5)
 #
 # Example:
-#   ./client_test.sh 10.0.2.100 9000
+#   ./client_test.sh 10.0.2.100 21240
 
 set -euo pipefail
 
 HOST="${1:-}"
-PORT="${2:-9000}"
+PORT="${2:-21240}"
 TIMEOUT="${3:-5}"
 ATTEMPTS=3
 

--- a/network-test-scripts/ec2-to-podman/podman_server_setup.sh
+++ b/network-test-scripts/ec2-to-podman/podman_server_setup.sh
@@ -5,18 +5,18 @@
 # Run this on the RHEL9 EC2 that hosts the Podman container.
 #
 # Usage: ./podman_server_setup.sh [HOST_PORT] [CONTAINER_PORT] [IMAGE]
-#   HOST_PORT       Port exposed on the RHEL9 EC2 host (default: 9000)
-#   CONTAINER_PORT  Port nc listens on inside the container (default: 9000)
+#   HOST_PORT       Port exposed on the RHEL9 EC2 host (default: 21240)
+#   CONTAINER_PORT  Port nc listens on inside the container (default: 21240)
 #   IMAGE           Container image to use (default: registry.access.redhat.com/ubi9/ubi-minimal)
 #
 # Example:
-#   ./podman_server_setup.sh 9000 9000
+#   ./podman_server_setup.sh 21240 21240
 #   ./podman_server_setup.sh 8080 8080 debian:12
 
 set -euo pipefail
 
-HOST_PORT="${1:-9000}"
-CONTAINER_PORT="${2:-9000}"
+HOST_PORT="${1:-21240}"
+CONTAINER_PORT="${2:-21240}"
 IMAGE="${3:-registry.access.redhat.com/ubi9/ubi-minimal}"
 CONTAINER_NAME="nc-test-server"
 

--- a/network-test-scripts/fixes/fix_conntrack.sh
+++ b/network-test-scripts/fixes/fix_conntrack.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# fix_conntrack.sh - Fix connection tracking (conntrack) issues that silently
+# drop connections even though tcpdump sees the packets arriving.
+#
+# Fixes:
+#   - Conntrack table full → new SYNs silently dropped
+#   - INVALID state entries from stale Podman NAT → mid-stream drops
+#   - rp_filter strict mode → drops NAT/container traffic
+#   - Undersized nf_conntrack_max
+#
+# Run on EITHER or BOTH hosts.
+#
+# Usage: ./fix_conntrack.sh [MODE] [MAX_ENTRIES]
+#   MODE         'flush' | 'tune' | 'all' (default: all)
+#   MAX_ENTRIES  Override the calculated conntrack max
+
+set -uo pipefail
+
+MODE="${1:-all}"
+CUSTOM_MAX="${2:-}"
+
+echo "============================================="
+echo " CONNTRACK FIX"
+echo "============================================="
+echo " Host : $(hostname)"
+echo " Mode : ${MODE}"
+echo "============================================="
+echo ""
+
+SUDO=""; [[ "${EUID}" -ne 0 ]] && SUDO="sudo"
+CHANGES=()
+
+CURRENT_MAX=$(${SUDO} sysctl -n net.netfilter.nf_conntrack_max 2>/dev/null || echo "65536")
+CURRENT_COUNT=$(${SUDO} sysctl -n net.netfilter.nf_conntrack_count 2>/dev/null || echo "0")
+PCT=$(awk "BEGIN{printf \"%.1f\", (${CURRENT_COUNT}/${CURRENT_MAX})*100}" 2>/dev/null || echo "?")
+echo "Current: max=${CURRENT_MAX}, count=${CURRENT_COUNT} (${PCT}% full)"
+echo ""
+
+# ── Flush ─────────────────────────────────────────────────────────────────────
+if [[ "${MODE}" == "flush" || "${MODE}" == "all" ]]; then
+    echo "── Flushing stale entries ──────────────────"
+    if command -v conntrack &>/dev/null || ${SUDO} conntrack --version &>/dev/null 2>&1; then
+        INVALID=$(${SUDO} conntrack -L 2>/dev/null | grep -c INVALID || echo 0)
+        if [[ "${INVALID}" -gt 0 ]]; then
+            ${SUDO} conntrack -D --state INVALID 2>/dev/null && \
+                echo "  [OK ] Removed ${INVALID} INVALID entries." || true
+            CHANGES+=("removed ${INVALID} INVALID conntrack entries")
+        else
+            echo "  [OK ] No INVALID entries."
+        fi
+
+        TW=$(${SUDO} conntrack -L 2>/dev/null | grep -c TIME_WAIT || echo 0)
+        if [[ "${TW}" -gt 1000 ]]; then
+            ${SUDO} conntrack -D --state TIME_WAIT 2>/dev/null && \
+                echo "  [OK ] Flushed ${TW} TIME_WAIT entries." || true
+            CHANGES+=("flushed ${TW} TIME_WAIT entries")
+        fi
+
+        NEW_PCT=$(awk "BEGIN{
+            c=$(${SUDO} sysctl -n net.netfilter.nf_conntrack_count 2>/dev/null || echo 0)
+            printf \"%.0f\", (c/${CURRENT_MAX})*100
+        }" 2>/dev/null || echo 0)
+        if [[ "${NEW_PCT}" -gt 90 ]]; then
+            echo "  Table still ${NEW_PCT}% full. Performing FULL flush (brief gap)..."
+            ${SUDO} conntrack -F 2>/dev/null && echo "  [OK ] Full flush done." || true
+            CHANGES+=("full conntrack flush")
+        fi
+    else
+        echo "  conntrack not installed. Run: dnf install conntrack-tools"
+    fi
+fi
+
+echo ""
+
+# ── Tune ──────────────────────────────────────────────────────────────────────
+if [[ "${MODE}" == "tune" || "${MODE}" == "all" ]]; then
+    echo "── Tuning limits ───────────────────────────"
+    RAM_KB=$(grep MemTotal /proc/meminfo 2>/dev/null | awk '{print $2}' || echo 2097152)
+    RECOMMENDED=$(awk "BEGIN{printf \"%d\", (${RAM_KB} * 1024 * 0.10) / 350}")
+    [[ "${RECOMMENDED}" -lt 65536 ]] && RECOMMENDED=65536
+    [[ "${RECOMMENDED}" -gt 2097152 ]] && RECOMMENDED=2097152
+    NEW_MAX="${CUSTOM_MAX:-${RECOMMENDED}}"
+
+    echo "  RAM: $((RAM_KB/1024))MB | current max: ${CURRENT_MAX} | recommended: ${NEW_MAX}"
+
+    if [[ "${NEW_MAX}" -gt "${CURRENT_MAX}" ]]; then
+        ${SUDO} sysctl -w net.netfilter.nf_conntrack_max="${NEW_MAX}"
+        CONF="/etc/sysctl.d/99-conntrack.conf"
+        ${SUDO} tee "${CONF}" > /dev/null <<EOF
+net.netfilter.nf_conntrack_max = ${NEW_MAX}
+net.netfilter.nf_conntrack_tcp_timeout_established = 1800
+net.netfilter.nf_conntrack_tcp_timeout_time_wait = 30
+net.netfilter.nf_conntrack_tcp_timeout_fin_wait = 30
+net.netfilter.nf_conntrack_tcp_timeout_close_wait = 15
+EOF
+        echo "  [OK ] Written to ${CONF}"
+        CHANGES+=("nf_conntrack_max → ${NEW_MAX}")
+    else
+        echo "  [OK ] Current max is already sufficient."
+    fi
+
+    ${SUDO} sysctl -w net.netfilter.nf_conntrack_tcp_timeout_established=1800 2>/dev/null && \
+        echo "  [OK ] established timeout → 1800s" || true
+    ${SUDO} sysctl -w net.netfilter.nf_conntrack_tcp_timeout_time_wait=30 2>/dev/null && \
+        echo "  [OK ] time_wait timeout   → 30s" || true
+    CHANGES+=("reduced TCP conntrack timeouts")
+fi
+
+echo ""
+
+# ── rp_filter ─────────────────────────────────────────────────────────────────
+echo "── rp_filter ───────────────────────────────"
+RP=$(cat /proc/sys/net/ipv4/conf/all/rp_filter 2>/dev/null || echo 0)
+echo "  Current net.ipv4.conf.all.rp_filter: ${RP}"
+if [[ "${RP}" == "1" ]]; then
+    ${SUDO} sysctl -w net.ipv4.conf.all.rp_filter=2 2>/dev/null
+    ${SUDO} sysctl -w net.ipv4.conf.default.rp_filter=2 2>/dev/null || true
+    for iface in $(ls /proc/sys/net/ipv4/conf/ 2>/dev/null | grep -vE 'all|default|lo'); do
+        ${SUDO} sysctl -w "net.ipv4.conf.${iface}.rp_filter=2" 2>/dev/null || true
+    done
+    CONF="/etc/sysctl.d/99-conntrack.conf"
+    ${SUDO} grep -q rp_filter "${CONF}" 2>/dev/null || \
+        echo -e "net.ipv4.conf.all.rp_filter = 2\nnet.ipv4.conf.default.rp_filter = 2" | ${SUDO} tee -a "${CONF}" > /dev/null
+    echo "  [OK ] rp_filter changed strict(1) → loose(2)"
+    CHANGES+=("rp_filter 1→2 (loose)")
+else
+    echo "  [OK ] rp_filter already 0 or loose."
+fi
+
+echo ""
+echo "============================================="
+echo " CHANGES"
+echo "============================================="
+[[ ${#CHANGES[@]} -eq 0 ]] && echo " None needed." || \
+    for c in "${CHANGES[@]}"; do echo "  [+] ${c}"; done
+echo ""
+echo " Next: ec2-to-podman/client_test.sh <RHEL9_IP> 21240"
+echo "============================================="

--- a/network-test-scripts/fixes/fix_podman_firewall.sh
+++ b/network-test-scripts/fixes/fix_podman_firewall.sh
@@ -11,12 +11,12 @@
 #   - firewall-cmd --list-all doesn't show the port as allowed
 #
 # Usage: ./fix_podman_firewall.sh [PORT] [ZONE]
-#   PORT  Port to open (default: 9000)
+#   PORT  Port to open (default: 21240)
 #   ZONE  firewalld zone (default: public)
 
 set -euo pipefail
 
-PORT="${1:-9000}"
+PORT="${1:-21240}"
 ZONE="${2:-public}"
 PROTO="tcp"
 

--- a/network-test-scripts/fixes/fix_selinux_podman.sh
+++ b/network-test-scripts/fixes/fix_selinux_podman.sh
@@ -6,12 +6,12 @@
 # Run on the RHEL9 EC2 (Podman host) as root / with sudo.
 #
 # Usage: ./fix_selinux_podman.sh [PORT] [MODE]
-#   PORT  Port the container is using (default: 9000)
+#   PORT  Port the container is using (default: 21240)
 #   MODE  'fix' to apply changes, 'diagnose' to only report (default: diagnose)
 
 set -uo pipefail
 
-PORT="${1:-9000}"
+PORT="${1:-21240}"
 MODE="${2:-diagnose}"
 
 echo "============================================="

--- a/network-test-scripts/fixes/restart_podman_network.sh
+++ b/network-test-scripts/fixes/restart_podman_network.sh
@@ -14,8 +14,8 @@
 set -uo pipefail
 
 CONTAINER="${1:-nc-test-server}"
-HOST_PORT="${2:-9000}"
-CONTAINER_PORT="${3:-9000}"
+HOST_PORT="${2:-21240}"
+CONTAINER_PORT="${3:-21240}"
 
 echo "============================================="
 echo " PODMAN NETWORK RESTART"


### PR DESCRIPTION
… extended diagnostics

Updates default port from 9000 to 21240 across all scripts. Adds 6 new scripts for diagnosing and fixing the RHEL8/RHEL9+Podman connectivity issue.

New diagnostics:
  check_conntrack.sh     - conntrack table capacity, INVALID/stale Podman NAT
                           entries; explains tcpdump-sees-SYN-but-nc-drops-it
  check_tcp_wrappers.sh  - hosts.allow/hosts.deny; TCP Wrappers acts silently
                           independent of firewalld on custom RHEL8 builds
  check_custom_rhel8.sh  - 13 hardened-RHEL8 checks: fail2ban bans, custom
                           iptables chains, ipset blocklists, rp_filter strict
                           mode, NetworkManager zones, MTU mismatch, PAM
                           access.conf, ip_unprivileged_port_start, FIPS,
                           netfilter modules, auditd syscall rules, EDR agents
  check_debian_pod.sh    - inspects Debian dev pod via podman exec: ufw,
                           internal iptables, nc flavour (openbsd vs ncat),
                           listening ports, outbound connectivity test

New ec2-to-ec2:
  alt_connect_test.sh    - tries nc, bash /dev/tcp, socat, curl, telnet,
                           python3 socket, nmap, openssl; cross-referencing
                           pass/fail isolates whether the problem is the
                           network path or nc/tool-specific

New fixes:
  fix_conntrack.sh       - flush INVALID/TIME_WAIT entries, auto-tune
                           nf_conntrack_max from RAM, shorten TCP timeouts,
                           fix rp_filter strict to loose

https://claude.ai/code/session_01M8o3H4J2ggjrMqbMp5cA2S

## Summary

- What changed?
- Why was this change needed?

## Scope

- [ ] Core PR reviewer
- [ ] Chatbot / Teams
- [ ] KB sync
- [ ] Release notes
- [ ] Sprint report
- [ ] Test generation
- [ ] PR description
- [ ] Terraform / IaC
- [ ] Docs / runbooks
- [ ] CI / quality gates

## Validation

- [ ] `ruff check src tests scripts`
- [ ] `pytest -q`
- [ ] `terraform fmt -check` (if IaC changed)
- [ ] `terraform validate` (if IaC changed)

## PR Title Convention

Use a scoped title that reflects shipped impact (this becomes the squash commit subject):

- `feat(scope): short outcome`
- `fix(scope): short outcome`
- `chore(scope): short outcome`

Examples:

- `feat(reviewer): add Jira enrichment for ticket-aware findings`
- `feat(platform): add sprint report, test-gen, and PR description agents`
- `chore(ci): add lint/test and terraform quality gates`
